### PR TITLE
Unique Effects

### DIFF
--- a/plugin-volume/Cargo.toml
+++ b/plugin-volume/Cargo.toml
@@ -9,6 +9,4 @@ crate-type = [ "cdylib" ]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-lazy_static = "1.4"
 rambot-api = { path = "../rambot-api" }
-regex = "1.6"

--- a/rambot-api/src/lib.rs
+++ b/rambot-api/src/lib.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::io;
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 
@@ -235,16 +236,16 @@ pub trait AudioSourceResolver : Send + Sync {
 /// audio data it outputs by the volume number.
 pub trait EffectResolver : Send + Sync {
 
-    /// Indicates whether this resolver can construct an effect from the given
-    /// descriptor.
-    fn can_resolve(&self, descriptor: &str) -> bool;
+    fn name(&self) -> &str;
+
+    fn unique(&self) -> bool;
 
     /// Generates an [AudioSource] trait object that yields audio constituting
-    /// the effect defined by the given descriptor applied to the given child.
-    /// If [EffectResolver::can_resolve] returns `true`, this should probably
-    /// work, however it may still return an error message should an unexpected
-    /// problem occur.
-    fn resolve(&self, descriptor: &str, child: Box<dyn AudioSource + Send>)
+    /// the effect defined by the given key-value pairs applied to the given
+    /// child. This may return an error should the provided key-value map
+    /// contain invalid inputs.
+    fn resolve(&self, key_values: &HashMap<String, String>,
+        child: Box<dyn AudioSource + Send>)
         -> Result<Box<dyn AudioSource + Send>, String>;
 }
 

--- a/rambot/src/command/effect.rs
+++ b/rambot/src/command/effect.rs
@@ -19,7 +19,13 @@ pub fn get_effect_commands() -> &'static CommandGroup {
 #[description("Adds an effect to the layer with the given name.")]
 async fn add(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult {
     let layer = args.single::<String>()?;
-    let effect = args.rest();
+    let effect = match args.rest().parse() {
+        Ok(e) => e,
+        Err(e) => {
+            msg.reply(ctx, e).await?;
+            return Ok(());
+        }
+    };
     let res = with_mixer(ctx, msg,
         |mut mixer| mixer.add_effect(&layer, effect)).await;
 

--- a/rambot/src/effect.rs
+++ b/rambot/src/effect.rs
@@ -1,0 +1,166 @@
+use std::collections::HashMap;
+use std::fmt::{self, Display, Formatter};
+use std::iter::Peekable;
+use std::str::{Chars, FromStr};
+
+pub enum ParseEffectDescriptorError {
+    MissingClosingQuote,
+    MissingDelimiter(char),
+    InvalidDelimiter {
+        expected: char,
+        found: char
+    },
+    UnexpectedContinuation
+}
+
+impl Display for ParseEffectDescriptorError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            ParseEffectDescriptorError::MissingClosingQuote =>
+                write!(f, "Missing closing quote in string."),
+            ParseEffectDescriptorError::MissingDelimiter(d) =>
+                write!(f, "Missing delimiter: \'{}\'.", d),
+            ParseEffectDescriptorError::InvalidDelimiter {
+                expected,
+                found
+            } => write!(f, "Expected delimiter \'{}\', but found: \'{}\'.",
+                expected, found),
+            ParseEffectDescriptorError::UnexpectedContinuation =>
+                write!(f, "Expected end, but effect descriptor continued.")
+        }
+    }
+}
+
+pub struct EffectDescriptor {
+    pub name: String,
+    pub key_values: HashMap<String, String>
+}
+
+impl FromStr for EffectDescriptor {
+    type Err = ParseEffectDescriptorError;
+
+    fn from_str(code: &str)
+            -> Result<EffectDescriptor, ParseEffectDescriptorError> {
+        let mut chars = code.chars().peekable();
+        let name = parse_string(&mut chars)?;
+        
+        let key_values = match chars.next() {
+            Some('(') => Some(parse_key_value(&mut chars)?),
+            Some(c) => return Err(ParseEffectDescriptorError::InvalidDelimiter {
+                expected: '(',
+                found: c
+            }),
+            None => None
+        };
+        
+        if key_values.is_some() {
+            consume_delimiter(&mut chars, ')')?;
+        }
+        
+        if chars.next().is_some() {
+            return Err(ParseEffectDescriptorError::UnexpectedContinuation);
+        }
+        
+        let key_values = key_values.unwrap_or_else(HashMap::new);
+        
+        Ok(EffectDescriptor {
+            name,
+            key_values
+        })
+    }
+}
+
+fn is_delimiter(c: char) -> bool {
+    c == '(' || c == ')' || c == ',' || c == '='
+}
+
+fn parse_string<'a>(chars: &mut Peekable<Chars<'a>>)
+        -> Result<String, ParseEffectDescriptorError> {
+    let mut s = String::new();
+    let mut quote_mode = false;
+
+    if let Some(&first) = chars.peek() {
+        if first == '\"' {
+            chars.next();
+            quote_mode = true;
+        }
+    }
+
+    let mut escaped = false;
+
+    while let Some(&c) = chars.peek() {
+        let mut new_escaped = false;
+
+        if is_delimiter(c) {
+            if !quote_mode {
+                return Ok(s);
+            }
+        }
+        else if c == '\\' {
+            if quote_mode && !escaped {
+                new_escaped = true;
+            }
+        }
+        else if c == '\"' {
+            if quote_mode && !escaped {
+                chars.next();
+                return Ok(s);
+            }
+        }
+
+        escaped = new_escaped;
+        chars.next();
+        s.push(c);
+    }
+
+    if quote_mode {
+        Err(ParseEffectDescriptorError::MissingClosingQuote)
+    }
+    else {
+        Ok(s)
+    }
+}
+
+fn consume_delimiter<'a>(chars: &mut Peekable<Chars<'a>>, delimiter: char)
+        -> Result<(), ParseEffectDescriptorError> {
+    match chars.next() {
+        Some(c) => {
+            if c == delimiter {
+                Ok(())
+            }
+            else {
+                Err(ParseEffectDescriptorError::InvalidDelimiter {
+                    expected: '=',
+                    found: c
+                })
+            }
+        },
+        None => Err(ParseEffectDescriptorError::MissingDelimiter(delimiter))
+    }
+}
+
+fn parse_key_value<'a>(chars: &mut Peekable<Chars<'a>>)
+        -> Result<HashMap<String, String>, ParseEffectDescriptorError> {
+    let mut first = true;
+    let mut result = HashMap::new();
+
+    while chars.peek().is_some() {
+        if first {
+            first = false;
+        }
+        else {
+            consume_delimiter(chars, ',')?;
+        }
+
+        let key = parse_string(chars)?;
+        consume_delimiter(chars, '=')?;
+        let value = parse_string(chars)?;
+        result.insert(key, value);
+
+        if chars.peek() == Some(&')') {
+            break;
+        }
+    }
+
+    Ok(result)
+}

--- a/rambot/src/main.rs
+++ b/rambot/src/main.rs
@@ -22,6 +22,7 @@ use std::sync::Arc;
 pub mod audio;
 pub mod command;
 pub mod config;
+pub mod effect;
 pub mod logging;
 pub mod plugin;
 pub mod state;


### PR DESCRIPTION
Effects can now specify that they are unique, which causes all effects of the same kind to be removed when a new one is added.
This is useful to allow users to override, for example, the volume instead of deleting the old one and adding a new one.