### PR TITLE
Double mapped audio buffer

### DIFF
--- a/rambot/Cargo.toml
+++ b/rambot/Cargo.toml
@@ -15,6 +15,6 @@ serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"
 serenity = "0.10"
 simplelog = "0.12"
-slice-deque = "0.3"
 songbird = "0.2"
 tokio = { version = "1.0", features = [ "macros", "rt-multi-thread" ] }
+vmcircbuffer = "0.0.9"


### PR DESCRIPTION
Modified the mixer to use a double mapped ring buffer for synchronization of layers. This seems to improve performance of the mixer by ~20 %.