### PR TITLE
Fixed error reporting for double disconnect

### DIFF
--- a/rambot-proc-macro/src/lib.rs
+++ b/rambot-proc-macro/src/lib.rs
@@ -16,12 +16,14 @@ use syn::{
     Lit,
     Meta,
     NestedMeta,
+    Pat,
     Path,
-    PathSegment,
     PathArguments,
+    PathSegment,
     PatType,
+    ReturnType,
     Stmt,
-    Type, ReturnType, Pat
+    Type
 };
 use syn::punctuated::Punctuated;
 use syn::token::{Brace, Bracket, Pound};


### PR DESCRIPTION
After disconnecting, running another command that requires connection would fail to raise an error and instead panic.
This is now fixed.
This resolves #57 