### PR TITLE
Return on syntax error

### DIFF
--- a/rambot-proc-macro/src/lib.rs
+++ b/rambot-proc-macro/src/lib.rs
@@ -331,6 +331,7 @@ fn rambot_command_do(attr: Vec<NestedMeta>, mut item: ItemFn)
             if !#args_ident.is_empty() {
                 #msg_ident.reply(#ctx_ident,
                     "Expected end, but received more arguments.").await?;
+                return Ok(());
             }
         });
     }


### PR DESCRIPTION
When parsing commands and encountering a syntax error, the bot will now exit command execution after sending an error message, preventing double errors and unexpected side effects.
This resolves #65