### PR TITLE
Bump versions to 0.1.2

### DIFF
--- a/plugin-commons/Cargo.toml
+++ b/plugin-commons/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plugin-commons"
-version = "0.1.0"
+version = "0.1.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/plugin-filters/Cargo.toml
+++ b/plugin-filters/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plugin-filters"
-version = "0.1.0"
+version = "0.1.2"
 edition = "2021"
 
 [lib]

--- a/plugin-folder-list/Cargo.toml
+++ b/plugin-folder-list/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plugin-folder-list"
-version = "0.1.0"
+version = "0.1.2"
 edition = "2021"
 
 [lib]

--- a/plugin-json-list/Cargo.toml
+++ b/plugin-json-list/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plugin-json-list"
-version = "0.1.0"
+version = "0.1.2"
 edition = "2021"
 
 [lib]

--- a/plugin-loop/Cargo.toml
+++ b/plugin-loop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plugin-loop"
-version = "0.1.0"
+version = "0.1.2"
 edition = "2021"
 
 [lib]

--- a/plugin-mp3/Cargo.toml
+++ b/plugin-mp3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plugin-mp3"
-version = "0.1.0"
+version = "0.1.2"
 edition = "2021"
 
 [lib]

--- a/plugin-ogg/Cargo.toml
+++ b/plugin-ogg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plugin-ogg"
-version = "0.1.0"
+version = "0.1.2"
 edition = "2021"
 
 [lib]

--- a/plugin-shuffle/Cargo.toml
+++ b/plugin-shuffle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plugin-shuffle"
-version = "0.1.0"
+version = "0.1.2"
 edition = "2021"
 
 [lib]

--- a/plugin-volume/Cargo.toml
+++ b/plugin-volume/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plugin-volume"
-version = "0.1.0"
+version = "0.1.2"
 edition = "2021"
 
 [lib]

--- a/plugin-wave/Cargo.toml
+++ b/plugin-wave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plugin-wave"
-version = "0.1.0"
+version = "0.1.2"
 edition = "2021"
 
 [lib]

--- a/rambot-api/Cargo.toml
+++ b/rambot-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rambot-api"
-version = "0.1.0"
+version = "0.1.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/rambot-proc-macro/Cargo.toml
+++ b/rambot-proc-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rambot-proc-macro"
-version = "0.1.0"
+version = "0.1.2"
 edition = "2021"
 
 [lib]

--- a/rambot/Cargo.toml
+++ b/rambot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rambot"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
As `rambot-api` and `rambot-proc-macro` were changed and all crates are dependent on at least one of them, all versions were updated.