### PR TITLE
Effect/Adapter documentation

### DIFF
--- a/plugin-filters/src/lib.rs
+++ b/plugin-filters/src/lib.rs
@@ -6,6 +6,8 @@ use crate::kernel::KernelFilter;
 use rambot_api::{
     AudioSource,
     EffectResolver,
+    ModifierDocumentation,
+    ModifierDocumentationBuilder,
     Plugin,
     PluginConfig,
     ResolveEffectError,
@@ -34,6 +36,17 @@ impl EffectResolver for GaussianEffectResolver {
         false
     }
 
+    fn documentation(&self) -> ModifierDocumentation {
+        ModifierDocumentationBuilder::new()
+            .with_short_summary("Applies a gaussian lowpass filter to the \
+                audio.")
+            .with_parameter("sigma", "The width of the gaussian kernel. \
+                Higher values cause lower frequencies to be cut. \
+                Experimentation is required. Typical values are in the range \
+                1 to 100.")
+            .build().unwrap()
+    }
+
     fn resolve(&self, key_values: &HashMap<String, String>,
             child: Box<dyn AudioSource + Send>)
             -> Result<Box<dyn AudioSource + Send>, ResolveEffectError> {
@@ -56,6 +69,17 @@ impl EffectResolver for InvGaussianEffectResolver {
 
     fn unique(&self) -> bool {
         false
+    }
+
+    fn documentation(&self) -> ModifierDocumentation {
+        ModifierDocumentationBuilder::new()
+            .with_short_summary("Subtracts a gaussian lowpass filter from the \
+                audio, thus obtaining a highpass filter.")
+            .with_parameter("sigma", "The width of the gaussian kernel. \
+                Higher values cause less higher frequencies to be cut. \
+                Experimentation is required. Typical values are in the range \
+                1 to 100.")
+            .build().unwrap()
     }
 
     fn resolve(&self, key_values: &HashMap<String, String>,

--- a/plugin-loop/src/lib.rs
+++ b/plugin-loop/src/lib.rs
@@ -1,6 +1,8 @@
 use rambot_api::{
     AdapterResolver,
     AudioSourceList,
+    ModifierDocumentation,
+    ModifierDocumentationBuilder,
     Plugin,
     PluginConfig,
     ResolverRegistry
@@ -41,6 +43,13 @@ impl AdapterResolver for LoopAdapterResolver {
 
     fn unique(&self) -> bool {
         true
+    }
+
+    fn documentation(&self) -> ModifierDocumentation {
+        ModifierDocumentationBuilder::new()
+            .with_short_summary(
+                "Loops a playlist or single piece indefinitely.")
+            .build().unwrap()
     }
 
     fn resolve(&self, _key_values: &HashMap<String, String>,

--- a/plugin-shuffle/src/lib.rs
+++ b/plugin-shuffle/src/lib.rs
@@ -1,6 +1,8 @@
 use rambot_api::{
     AdapterResolver,
     AudioSourceList,
+    ModifierDocumentation,
+    ModifierDocumentationBuilder,
     Plugin,
     PluginConfig,
     ResolverRegistry
@@ -61,6 +63,16 @@ impl AdapterResolver for ShuffleAdapterResolver {
 
     fn unique(&self) -> bool {
         true
+    }
+
+    fn documentation(&self) -> ModifierDocumentation {
+        ModifierDocumentationBuilder::new()
+            .with_short_summary("Shuffles a playlist randomly.")
+            .with_long_summary("Shuffles a playlist randomly. In case of an \
+                infinite list (e.g. a looped list), the first segment of \
+                distinct entries until the first duplicate is shuffled, \
+                followed by the second segment etc.")
+            .build().unwrap()
     }
 
     fn resolve(&self, _key_values: &HashMap<String, String>,

--- a/plugin-volume/src/lib.rs
+++ b/plugin-volume/src/lib.rs
@@ -1,11 +1,13 @@
 use rambot_api::{
     AudioSource,
     EffectResolver,
+    ModifierDocumentation,
+    ModifierDocumentationBuilder,
     Plugin,
-    Sample,
     PluginConfig,
     ResolveEffectError,
-    ResolverRegistry
+    ResolverRegistry,
+    Sample
 };
 
 use std::{io, collections::HashMap};
@@ -51,6 +53,18 @@ impl EffectResolver for VolumeEffectResolver {
 
     fn unique(&self) -> bool {
         true
+    }
+
+    fn documentation(&self) -> ModifierDocumentation {
+        ModifierDocumentationBuilder::new()
+            .with_short_summary("Controls the volume.")
+            .with_long_summary(
+                "Controls the volume by multiplying all audio with a factor. \
+                You can use this effect by writing `volume=...`.")
+            .with_parameter("volume",
+                "The factor by which the volume is multiplied where 1 \
+                represents full volume and 0 is absolutely quiet.")
+            .build().unwrap()
     }
 
     fn resolve(&self, key_values: &HashMap<String, String>,

--- a/rambot-api/src/lib.rs
+++ b/rambot-api/src/lib.rs
@@ -12,6 +12,8 @@ pub use resolver::{
     AudioSourceListResolver,
     AudioSourceResolver,
     EffectResolver,
+    ModifierDocumentation,
+    ModifierDocumentationBuilder,
     ResolveEffectError,
     ResolverRegistry
 };

--- a/rambot-api/src/resolver.rs
+++ b/rambot-api/src/resolver.rs
@@ -136,7 +136,7 @@ impl Display for ModifierDocumentation {
             return Ok(());
         }
 
-        write!(f, "\n")?;
+        writeln!(f)?;
 
         for parameter in &self.parameters {
             write!(f, "\n- {}", parameter)?;
@@ -277,6 +277,12 @@ impl ModifierDocumentationBuilder {
                 long_summary,
                 parameters: self.parameters
             })
+    }
+}
+
+impl Default for ModifierDocumentationBuilder {
+    fn default() -> ModifierDocumentationBuilder {
+        ModifierDocumentationBuilder::new()
     }
 }
 

--- a/rambot-api/src/resolver.rs
+++ b/rambot-api/src/resolver.rs
@@ -95,6 +95,191 @@ impl Display for ResolveEffectError {
     }
 }
 
+struct ModifierParameterDocumentation {
+    name: String,
+    description: String
+}
+
+impl Display for ModifierParameterDocumentation {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "`{}`: {}", &self.name, &self.description)
+    }
+}
+
+/// Documentation of a modifier (effect or adapter) to be displayed to the user
+/// of the bot. The short form can be accessed by
+/// [ModifierDocumentation::short_summary] while a long markdown version is
+/// available behind the implementation of the [Display] trait.
+///
+/// To construct instances of this type, use the
+/// [ModifierDocumentationBuilder].
+pub struct ModifierDocumentation {
+    short_summary: String,
+    long_summary: String,
+    parameters: Vec<ModifierParameterDocumentation>
+}
+
+impl ModifierDocumentation {
+
+    /// Gets a short summary of the functionality of the documented modifier.
+    /// This is used for the overview page.
+    pub fn short_summary(&self) -> &str {
+        &self.short_summary
+    }
+}
+
+impl Display for ModifierDocumentation {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", &self.long_summary)?;
+
+        if self.parameters.is_empty() {
+            return Ok(());
+        }
+
+        write!(f, "\n")?;
+
+        for parameter in &self.parameters {
+            write!(f, "\n- {}", parameter)?;
+        }
+
+        Ok(())
+    }
+}
+
+/// A builder for [ModifierDocumentation]s. To construct a modifier
+/// documentation, create a new builder using
+/// [ModifierDocumentationBuilder::new], specify at least a short summary
+/// using [ModifierDocumentationBuilder::with_short_summary], and then build
+/// the final documentation using [ModifierDocumentation::build]. Further
+/// information can be provided with other methods. You do not need to provide
+/// the effect/adapter name, as that is taken from context.
+///
+/// A simple usage example is shown below.
+///
+/// ```
+/// // Documentation for a volume effect
+///
+/// let doc = ModifierDocumentationBuilder::new()
+///     .with_short_summary("Controls the volume of a layer.")
+///     .with_long_summary(
+///         "Controls the volume of a layer by multiplying all audio with a \
+///         given factor.")
+///     .with_parameter("volume", "The factor by which audio is multiplied.")
+///     .build();
+/// ```
+pub struct ModifierDocumentationBuilder {
+    short_summary: Option<String>,
+    long_summary: Option<String>,
+    parameters: Vec<ModifierParameterDocumentation>
+}
+
+impl ModifierDocumentationBuilder {
+
+    /// Creates a new modifier documentation builder.
+    pub fn new() -> ModifierDocumentationBuilder {
+        ModifierDocumentationBuilder {
+            short_summary: None,
+            long_summary: None,
+            parameters: Vec::new()
+        }
+    }
+
+    /// Specify a short summary for this effect/adapter to be displayed in the
+    /// overview. If no long summary has been specified, it will be assigned to
+    /// the given short summary as well.
+    ///
+    /// # Arguments
+    ///
+    /// * `summary`: A short summary for this effect/adapter. Markdown is
+    /// supported.
+    ///
+    /// # Returns
+    ///
+    /// This builder after the operation. Useful for chaining.
+    pub fn with_short_summary<S>(mut self, summary: S)
+        -> ModifierDocumentationBuilder
+    where
+        S: Into<String>
+    {
+        let summary = summary.into();
+
+        self.long_summary.get_or_insert_with(|| summary.clone());
+        self.short_summary = Some(summary);
+        self
+    }
+
+    /// Specify a long summary for this effect/adapter to be displayed in the
+    /// effect/adapter specific help page.
+    ///
+    /// # Arguments
+    ///
+    /// * `summary`: A long summary for this effect/adapter. Markdown is
+    /// supported.
+    ///
+    /// # Returns
+    ///
+    /// This builder after the operation. Useful for chaining.
+    pub fn with_long_summary<S>(mut self, summary: S)
+        -> ModifierDocumentationBuilder
+    where
+        S: Into<String>
+    {
+        self.long_summary = Some(summary.into());
+        self
+    }
+
+    /// Adds a parameter documentation for a new parameter to the constructed
+    /// modifier documentation. To add multiple parameters, call this method
+    /// multiple times. The parameters will be displayed top-to-bottom in the
+    /// order this method is called.
+    ///
+    /// # Arguments
+    ///
+    /// * `name`: The name of the documented parameter.
+    /// * `description`: A description to be displayed for the documented
+    /// parameter.
+    ///
+    /// # Returns
+    ///
+    /// This builder after the operation. Useful for chaining.
+    pub fn with_parameter<S1, S2>(mut self, name: S1, description: S2)
+        -> ModifierDocumentationBuilder
+    where
+        S1: Into<String>,
+        S2: Into<String>
+    {
+        let name = name.into();
+        let description = description.into();
+
+        self.parameters.push(ModifierParameterDocumentation {
+            name,
+            description
+        });
+
+        self
+    }
+
+    /// Builds the modifier documentation constructed from the data provided
+    /// with previous method calls. At least
+    /// [ModifierDocumentationBuilder::with_short_summary] is required to be
+    /// called before this.
+    ///
+    /// # Returns
+    ///
+    /// `Some(_)` with a new [ModifierDocumentation] instance with the
+    /// previously provided information. If no short summary has been
+    /// specified, `None` is returned.
+    pub fn build(self) -> Option<ModifierDocumentation> {
+        self.short_summary
+            .and_then(|short| self.long_summary.map(|long| (short, long)))
+            .map(|(short_summary, long_summary)| ModifierDocumentation {
+                short_summary,
+                long_summary,
+                parameters: self.parameters
+            })
+    }
+}
+
 /// A trait for resolvers which can create effects from key-value arguments.
 /// Similarly to [AudioSourceResolver]s, these effects are realized as
 /// [AudioSource]s, however they receive a child audio source whose output can
@@ -111,6 +296,10 @@ pub trait EffectResolver : Send + Sync {
     /// the old one is removed. This makes sense for example for a volume
     /// effect, where adding volume effects can be seen more like an "update".
     fn unique(&self) -> bool;
+
+    /// Constructs a [ModifierDocumentation] for this kind of effect. This is
+    /// displayed when executing the effect help command.
+    fn documentation(&self) -> ModifierDocumentation;
 
     /// Generates an [AudioSource] trait object that yields audio constituting
     /// the effect defined by the given key-value pairs applied to the given
@@ -202,6 +391,10 @@ pub trait AdapterResolver : Send + Sync {
     /// adapter, because looping an already infinite (because looped) audio
     /// source list is redundant.
     fn unique(&self) -> bool;
+
+    /// Constructs a [ModifierDocumentation] for this kind of adapter. This is
+    /// displayed when executing the adapter help command.
+    fn documentation(&self) -> ModifierDocumentation;
 
     /// Generates an [AudioSourceList] trait object that yields audio source
     /// descriptors constituting the output of the adapter defined by the given

--- a/rambot-api/src/resolver.rs
+++ b/rambot-api/src/resolver.rs
@@ -157,6 +157,8 @@ impl Display for ModifierDocumentation {
 /// A simple usage example is shown below.
 ///
 /// ```
+/// use rambot_api::ModifierDocumentationBuilder;
+///
 /// // Documentation for a volume effect
 ///
 /// let doc = ModifierDocumentationBuilder::new()

--- a/rambot-api/src/resolver.rs
+++ b/rambot-api/src/resolver.rs
@@ -150,9 +150,9 @@ impl Display for ModifierDocumentation {
 /// documentation, create a new builder using
 /// [ModifierDocumentationBuilder::new], specify at least a short summary
 /// using [ModifierDocumentationBuilder::with_short_summary], and then build
-/// the final documentation using [ModifierDocumentation::build]. Further
-/// information can be provided with other methods. You do not need to provide
-/// the effect/adapter name, as that is taken from context.
+/// the final documentation using [ModifierDocumentationBuilder::build].
+/// Further information can be provided with other methods. You do not need to
+/// provide the effect/adapter name, as that is taken from context.
 ///
 /// A simple usage example is shown below.
 ///

--- a/rambot/src/command/adapter.rs
+++ b/rambot/src/command/adapter.rs
@@ -1,6 +1,11 @@
 use crate::audio::Layer;
-use crate::command::{list_layer_key_value_descriptors, with_mixer_and_layer};
+use crate::command::{
+    help_modifiers,
+    list_layer_key_value_descriptors,
+    with_mixer_and_layer
+};
 use crate::key_value::KeyValueDescriptor;
+use crate::plugin::PluginManager;
 
 use rambot_proc_macro::rambot_command;
 
@@ -11,7 +16,7 @@ use serenity::model::prelude::Message;
 
 #[group]
 #[prefix("adapter")]
-#[commands(add, clear, list)]
+#[commands(add, clear, help, list)]
 struct Adapter;
 
 /// Gets a [CommandGroup] for the commands with prefix `adapter`.
@@ -91,4 +96,17 @@ async fn list(ctx: &Context, msg: &Message, layer: String)
         -> CommandResult<Option<String>> {
     list_layer_key_value_descriptors(ctx, msg, layer, "Adapters",
         Layer::adapters).await
+}
+
+#[rambot_command(
+    description = "Lists all available adapters with a short description. If \
+        an adapter name is provided, a detailled description of the adapter and \
+        its parameters is given.",
+    usage = "[adapter]"
+)]
+async fn help(ctx: &Context, msg: &Message, adapter: Option<String>)
+        -> CommandResult<Option<String>> {
+    help_modifiers(ctx, msg, adapter, "Adapters", "adapter",
+        PluginManager::get_adapter_documentation, PluginManager::adapter_names)
+        .await
 }

--- a/rambot/src/command/effect.rs
+++ b/rambot/src/command/effect.rs
@@ -1,6 +1,11 @@
 use crate::audio::Layer;
-use crate::command::{list_layer_key_value_descriptors, with_mixer_and_layer};
+use crate::command::{
+    help_modifiers,
+    list_layer_key_value_descriptors,
+    with_mixer_and_layer
+};
 use crate::key_value::KeyValueDescriptor;
+use crate::plugin::PluginManager;
 
 use rambot_proc_macro::rambot_command;
 
@@ -11,7 +16,7 @@ use serenity::model::prelude::Message;
 
 #[group]
 #[prefix("effect")]
-#[commands(add, clear, list)]
+#[commands(add, clear, help, list)]
 struct Effect;
 
 /// Gets a [CommandGroup] for the commands with prefix `effect`.
@@ -91,4 +96,17 @@ async fn list(ctx: &Context, msg: &Message, layer: String)
         -> CommandResult<Option<String>> {
     list_layer_key_value_descriptors(
         ctx, msg, layer, "Effects", Layer::effects).await
+}
+
+#[rambot_command(
+    description = "Lists all available effects with a short description. If \
+        an effect name is provided, a detailled description of the effect and \
+        its parameters is given.",
+    usage = "[effect]"
+)]
+async fn help(ctx: &Context, msg: &Message, effect: Option<String>)
+        -> CommandResult<Option<String>> {
+    help_modifiers(ctx, msg, effect, "Effects", "effect",
+        PluginManager::get_effect_documentation, PluginManager::effect_names)
+        .await
 }


### PR DESCRIPTION
Added a way for plugins to provide documentation for their effects and adapters, which is displayed to the user in the context of the `!effect help` and `!adapter help` commands.