### PR TITLE
Audio Documentation

### DIFF
--- a/plugin-folder-list/src/lib.rs
+++ b/plugin-folder-list/src/lib.rs
@@ -1,4 +1,6 @@
 use rambot_api::{
+    AudioDocumentation,
+    AudioDocumentationBuilder,
     AudioSourceList,
     AudioSourceListResolver,
     Plugin,
@@ -39,6 +41,17 @@ struct FolderListResolver {
 }
 
 impl AudioSourceListResolver for FolderListResolver {
+
+    fn documentation(&self) -> AudioDocumentation {
+        AudioDocumentationBuilder::new()
+            .with_name("Folder Playlist")
+            .with_summary("Load directories as playlists.")
+            .with_description("Specify the path of a directory containing \
+                audio files relative to the bot root directory. This plugin \
+                will play all files in the directory as pieces of a playlist.")
+            .build().unwrap()
+    }
+
     fn can_resolve(&self, descriptor: &str) -> bool {
         match fs::metadata(descriptor) {
             Ok(meta) => meta.is_dir(),

--- a/plugin-json-list/src/lib.rs
+++ b/plugin-json-list/src/lib.rs
@@ -4,6 +4,8 @@ use std::collections::VecDeque;
 use std::io;
 
 use rambot_api::{
+    AudioDocumentation,
+    AudioDocumentationBuilder,
     AudioSourceList,
     AudioSourceListResolver,
     Plugin,
@@ -26,6 +28,17 @@ struct JsonAudioSourceListResolver {
 }
 
 impl AudioSourceListResolver for JsonAudioSourceListResolver {
+
+    fn documentation(&self) -> AudioDocumentation {
+        AudioDocumentationBuilder::new()
+            .with_name("Json Playlist")
+            .with_summary("Load JSON files as playlists.")
+            .with_description("Specify the path of a file with the `.json` \
+                extension relative to the bot root directory. This plugin \
+                will read the given file as a JSON array of strings and \
+                provide the individual elements as pieces of a playlist.")
+            .build().unwrap()
+    }
 
     fn can_resolve(&self, descriptor: &str) -> bool {
         self.file_manager.is_file_with_extension(descriptor, ".json")

--- a/plugin-mp3/src/lib.rs
+++ b/plugin-mp3/src/lib.rs
@@ -3,6 +3,8 @@ use minimp3::{self, Decoder, Frame};
 use plugin_commons::FileManager;
 
 use rambot_api::{
+    AudioDocumentation,
+    AudioDocumentationBuilder,
     AudioSource,
     AudioSourceResolver,
     Plugin,
@@ -101,6 +103,16 @@ struct Mp3AudioSourceResolver {
 }
 
 impl AudioSourceResolver for Mp3AudioSourceResolver {
+
+    fn documentation(&self) -> AudioDocumentation {
+        AudioDocumentationBuilder::new()
+            .with_name("Mp3")
+            .with_summary("Playback MP3 audio files.")
+            .with_description("Specify the path of a file with the `.mp3` \
+                extension relative to the bot root directory. This plugin \
+                will playback the given file.")
+            .build().unwrap()
+    }
 
     fn can_resolve(&self, descriptor: &str) -> bool {
         self.file_manager.is_file_with_extension(descriptor, ".mp3")

--- a/plugin-ogg/src/lib.rs
+++ b/plugin-ogg/src/lib.rs
@@ -3,6 +3,8 @@ use lewton::inside_ogg::OggStreamReader;
 use plugin_commons::FileManager;
 
 use rambot_api::{
+    AudioDocumentation,
+    AudioDocumentationBuilder,
     AudioSource,
     AudioSourceResolver,
     ResolverRegistry,
@@ -92,6 +94,16 @@ struct OggAudioSourceResolver {
 }
 
 impl AudioSourceResolver for OggAudioSourceResolver {
+
+    fn documentation(&self) -> AudioDocumentation {
+        AudioDocumentationBuilder::new()
+            .with_name("Ogg")
+            .with_summary("Playback OGG audio files.")
+            .with_description("Specify the path of a file with the `.ogg` \
+                extension relative to the bot root directory. This plugin \
+                will playback the given file.")
+            .build().unwrap()
+    }
 
     fn can_resolve(&self, descriptor: &str) -> bool {
         self.file_manager.is_file_with_extension(descriptor, ".ogg")

--- a/plugin-wave/src/lib.rs
+++ b/plugin-wave/src/lib.rs
@@ -5,6 +5,8 @@ use hound::{SampleFormat, WavIntoSamples, WavReader};
 use plugin_commons::FileManager;
 
 use rambot_api::{
+    AudioDocumentation,
+    AudioDocumentationBuilder,
     AudioSource,
     AudioSourceResolver,
     Plugin,
@@ -156,6 +158,17 @@ struct WaveAudioSourceResolver {
 }
 
 impl AudioSourceResolver for WaveAudioSourceResolver {
+
+    fn documentation(&self) -> AudioDocumentation {
+        AudioDocumentationBuilder::new()
+            .with_name("Wave")
+            .with_summary("Playback wave audio files.")
+            .with_description("Specify the path of a file with the `.wav` \
+                extension relative to the bot root directory. This plugin \
+                will playback the given file.")
+            .build().unwrap()
+    }
+
     fn can_resolve(&self, descriptor: &str) -> bool {
         self.file_manager.is_file_with_extension(descriptor, ".wav")
     }

--- a/rambot-api/src/documentation.rs
+++ b/rambot-api/src/documentation.rs
@@ -35,11 +35,11 @@ impl Display for AudioDocumentation {
 }
 
 /// A builder for [AudioDocumentation]s. To construct an audio documentation,
-/// create a new builder using [AudioDocumentation::new], specify at least a
-/// name and summary using [AudioDocumentation::with_name] and
-/// [AudioDocumentation::with_summary] respectively, and then build the final
-/// documentation using [AudioDocumentation::build]. Further information can be
-/// provided with other methods.
+/// create a new builder using [AudioDocumentationBuilder::new], specify at
+/// least a name and summary using [AudioDocumentationBuilder::with_name] and
+/// [AudioDocumentationBuilder::with_summary] respectively, and then build the
+/// final documentation using [AudioDocumentationBuilder::build]. Further
+/// information can be provided with other methods.
 ///
 /// A simple usage example is shown below.
 ///

--- a/rambot-api/src/documentation.rs
+++ b/rambot-api/src/documentation.rs
@@ -156,6 +156,12 @@ impl AudioDocumentationBuilder {
     }
 }
 
+impl Default for AudioDocumentationBuilder {
+    fn default() -> AudioDocumentationBuilder {
+        AudioDocumentationBuilder::new()
+    }
+}
+
 struct ModifierParameterDocumentation {
     name: String,
     description: String

--- a/rambot-api/src/documentation.rs
+++ b/rambot-api/src/documentation.rs
@@ -1,0 +1,350 @@
+use std::fmt::{self, Display, Formatter};
+
+/// Documentation for any audio (audio source or audio source list) to be
+/// displayed to the user of the bot. The overview entry can be accessed by
+/// [AudioDocumentation::overview_entry] while a long description page is
+/// available behind the implementation of the [Display] trait. Both versions
+/// use markdown.
+///
+/// To construct instances of this type, use the [AudioDocumentationBuilder].
+pub struct AudioDocumentation {
+    name: String,
+    summary: String,
+    description: String
+}
+
+impl AudioDocumentation {
+
+    /// Gets the name of the documented audio.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Gets an entry for an overview list of many audios. This contains the
+    /// name of the audio as well as a short summary. Uses markdown for
+    /// formatting.
+    pub fn overview_entry(&self) -> String {
+        format!("**{}**: {}", &self.name, &self.summary)
+    }
+}
+
+impl Display for AudioDocumentation {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "**{}**\n\n{}", &self.name, &self.description)
+    }
+}
+
+/// A builder for [AudioDocumentation]s. To construct an audio documentation,
+/// create a new builder using [AudioDocumentation::new], specify at least a
+/// name and summary using [AudioDocumentation::with_name] and
+/// [AudioDocumentation::with_summary] respectively, and then build the final
+/// documentation using [AudioDocumentation::build]. Further information can be
+/// provided with other methods.
+///
+/// A simple usage example is shown below.
+///
+/// ```
+/// use rambot_api::AudioDocumentationBuilder;
+///
+/// // Documentation for a folder playlist
+///
+/// let doc = AudioDocumentationBuilder::new()
+///     .with_name("folder-list")
+///     .with_summary("Plays all audio files in a given folder.")
+///     .build();
+/// ```
+pub struct AudioDocumentationBuilder {
+    name: Option<String>,
+    summary: Option<String>,
+    description: Option<String>
+}
+
+impl AudioDocumentationBuilder {
+
+    /// Creates a new audio documentation builder.
+    pub fn new() -> AudioDocumentationBuilder {
+        AudioDocumentationBuilder {
+            name: None,
+            summary: None,
+            description: None
+        }
+    }
+
+    /// Specify a name for this audio. Calling this function before building is
+    /// mandatory.
+    ///
+    /// # Arguments
+    ///
+    /// * `name`: The name of this audio. Markdown is supported.
+    ///
+    /// # Returns
+    ///
+    /// This builder after the operation. Useful for chaining.
+    pub fn with_name<S>(mut self, name: S) -> AudioDocumentationBuilder
+    where
+        S: Into<String>
+    {
+        self.name = Some(name.into());
+        self
+    }
+
+    /// Specify a short summary for this audio to be displayed in the overview
+    /// page. If no long description has been assigned yet, it will be set to
+    /// that same summary. Calling this function before building is mandatory.
+    ///
+    /// # Arguments
+    ///
+    /// * `summary`: A short summary for this audio. Markdown is supported.
+    ///
+    /// # Returns
+    ///
+    /// This builder after the operation. Useful for chaining.
+    pub fn with_summary<S>(mut self, summary: S) -> AudioDocumentationBuilder
+    where
+        S: Into<String>
+    {
+        let summary = summary.into();
+
+        self.description.get_or_insert_with(|| summary.clone());
+        self.summary = Some(summary);
+        self
+    }
+
+    /// Specify a longer description for this audio to be displayed in a
+    /// dedicated documentation page.
+    ///
+    /// # Arguments
+    ///
+    /// * `description`: A longer description for this audio. Markdown is
+    /// supported.
+    ///
+    /// # Returns
+    ///
+    /// This builder after the operation. Useful for chaining.
+    pub fn with_description<S>(mut self, description: S)
+        -> AudioDocumentationBuilder
+    where
+        S: Into<String>
+    {
+        self.description = Some(description.into());
+        self
+    }
+
+    /// Builds the audio documentation constructed from the data provided with
+    /// previous method calls. At least [AudioDocumentationBuilder::with_name]
+    /// and [AudioDocumentationBuilder::with_summary] are required to be called
+    /// before this.
+    ///
+    /// # Returns
+    ///
+    /// `Some(_)` with a new [AudioDocumentation] instance with the previously
+    /// provided information. If no name or no summary has been specified,
+    /// `None` is returned.
+    pub fn build(self) -> Option<AudioDocumentation> {
+        let parts = (self.name, self.summary, self.description);
+
+        if let (Some(name), Some(summary), Some(description)) = parts {
+            Some(AudioDocumentation {
+                name,
+                summary,
+                description
+            })
+        }
+        else {
+            None
+        }
+    }
+}
+
+struct ModifierParameterDocumentation {
+    name: String,
+    description: String
+}
+
+impl Display for ModifierParameterDocumentation {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "`{}`: {}", &self.name, &self.description)
+    }
+}
+
+/// Documentation of a modifier (effect or adapter) to be displayed to the user
+/// of the bot. The short form can be accessed by
+/// [ModifierDocumentation::short_summary] while a long markdown version is
+/// available behind the implementation of the [Display] trait.
+///
+/// To construct instances of this type, use the
+/// [ModifierDocumentationBuilder].
+pub struct ModifierDocumentation {
+    short_summary: String,
+    long_summary: String,
+    parameters: Vec<ModifierParameterDocumentation>
+}
+
+impl ModifierDocumentation {
+
+    /// Gets a short summary of the functionality of the documented modifier.
+    /// This is used for the overview page.
+    pub fn short_summary(&self) -> &str {
+        &self.short_summary
+    }
+}
+
+impl Display for ModifierDocumentation {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", &self.long_summary)?;
+
+        if self.parameters.is_empty() {
+            return Ok(());
+        }
+
+        writeln!(f)?;
+
+        for parameter in &self.parameters {
+            write!(f, "\n- {}", parameter)?;
+        }
+
+        Ok(())
+    }
+}
+
+/// A builder for [ModifierDocumentation]s. To construct a modifier
+/// documentation, create a new builder using
+/// [ModifierDocumentationBuilder::new], specify at least a short summary
+/// using [ModifierDocumentationBuilder::with_short_summary], and then build
+/// the final documentation using [ModifierDocumentationBuilder::build].
+/// Further information can be provided with other methods. You do not need to
+/// provide the effect/adapter name, as that is taken from context.
+///
+/// A simple usage example is shown below.
+///
+/// ```
+/// use rambot_api::ModifierDocumentationBuilder;
+///
+/// // Documentation for a volume effect
+///
+/// let doc = ModifierDocumentationBuilder::new()
+///     .with_short_summary("Controls the volume of a layer.")
+///     .with_long_summary(
+///         "Controls the volume of a layer by multiplying all audio with a \
+///         given factor.")
+///     .with_parameter("volume", "The factor by which audio is multiplied.")
+///     .build();
+/// ```
+pub struct ModifierDocumentationBuilder {
+    short_summary: Option<String>,
+    long_summary: Option<String>,
+    parameters: Vec<ModifierParameterDocumentation>
+}
+
+impl ModifierDocumentationBuilder {
+
+    /// Creates a new modifier documentation builder.
+    pub fn new() -> ModifierDocumentationBuilder {
+        ModifierDocumentationBuilder {
+            short_summary: None,
+            long_summary: None,
+            parameters: Vec::new()
+        }
+    }
+
+    /// Specify a short summary for this effect/adapter to be displayed in the
+    /// overview. If no long summary has been specified, it will be assigned to
+    /// the given short summary as well.
+    ///
+    /// # Arguments
+    ///
+    /// * `summary`: A short summary for this effect/adapter. Markdown is
+    /// supported.
+    ///
+    /// # Returns
+    ///
+    /// This builder after the operation. Useful for chaining.
+    pub fn with_short_summary<S>(mut self, summary: S)
+        -> ModifierDocumentationBuilder
+    where
+        S: Into<String>
+    {
+        let summary = summary.into();
+
+        self.long_summary.get_or_insert_with(|| summary.clone());
+        self.short_summary = Some(summary);
+        self
+    }
+
+    /// Specify a long summary for this effect/adapter to be displayed in the
+    /// effect/adapter specific help page.
+    ///
+    /// # Arguments
+    ///
+    /// * `summary`: A long summary for this effect/adapter. Markdown is
+    /// supported.
+    ///
+    /// # Returns
+    ///
+    /// This builder after the operation. Useful for chaining.
+    pub fn with_long_summary<S>(mut self, summary: S)
+        -> ModifierDocumentationBuilder
+    where
+        S: Into<String>
+    {
+        self.long_summary = Some(summary.into());
+        self
+    }
+
+    /// Adds a parameter documentation for a new parameter to the constructed
+    /// modifier documentation. To add multiple parameters, call this method
+    /// multiple times. The parameters will be displayed top-to-bottom in the
+    /// order this method is called.
+    ///
+    /// # Arguments
+    ///
+    /// * `name`: The name of the documented parameter.
+    /// * `description`: A description to be displayed for the documented
+    /// parameter.
+    ///
+    /// # Returns
+    ///
+    /// This builder after the operation. Useful for chaining.
+    pub fn with_parameter<S1, S2>(mut self, name: S1, description: S2)
+        -> ModifierDocumentationBuilder
+    where
+        S1: Into<String>,
+        S2: Into<String>
+    {
+        let name = name.into();
+        let description = description.into();
+
+        self.parameters.push(ModifierParameterDocumentation {
+            name,
+            description
+        });
+
+        self
+    }
+
+    /// Builds the modifier documentation constructed from the data provided
+    /// with previous method calls. At least
+    /// [ModifierDocumentationBuilder::with_short_summary] is required to be
+    /// called before this.
+    ///
+    /// # Returns
+    ///
+    /// `Some(_)` with a new [ModifierDocumentation] instance with the
+    /// previously provided information. If no short summary has been
+    /// specified, `None` is returned.
+    pub fn build(self) -> Option<ModifierDocumentation> {
+        self.short_summary
+            .and_then(|short| self.long_summary.map(|long| (short, long)))
+            .map(|(short_summary, long_summary)| ModifierDocumentation {
+                short_summary,
+                long_summary,
+                parameters: self.parameters
+            })
+    }
+}
+
+impl Default for ModifierDocumentationBuilder {
+    fn default() -> ModifierDocumentationBuilder {
+        ModifierDocumentationBuilder::new()
+    }
+}

--- a/rambot-api/src/lib.rs
+++ b/rambot-api/src/lib.rs
@@ -4,16 +4,21 @@ use std::env;
 use std::io;
 
 mod audio;
+mod documentation;
 mod resolver;
 
 pub use audio::{AudioSource, AudioSourceList, Sample};
+pub use documentation::{
+    AudioDocumentation,
+    AudioDocumentationBuilder,
+    ModifierDocumentation,
+    ModifierDocumentationBuilder
+};
 pub use resolver::{
     AdapterResolver,
     AudioSourceListResolver,
     AudioSourceResolver,
     EffectResolver,
-    ModifierDocumentation,
-    ModifierDocumentationBuilder,
     ResolveEffectError,
     ResolverRegistry
 };

--- a/rambot-api/src/resolver.rs
+++ b/rambot-api/src/resolver.rs
@@ -1,4 +1,6 @@
+use crate::AudioDocumentation;
 use crate::audio::{AudioSource, AudioSourceList};
+use crate::documentation::ModifierDocumentation;
 
 use std::collections::HashMap;
 use std::fmt::{self, Display, Formatter};
@@ -10,6 +12,10 @@ use std::fmt::{self, Display, Formatter};
 /// as descriptors paths to WAV files and generates audio sources which decode
 /// and stream those files.
 pub trait AudioSourceResolver : Send + Sync {
+
+    /// Constructs an [AudioDocumentation] for this kind of audio source. This
+    /// is displayed when executing the audio command.
+    fn documentation(&self) -> AudioDocumentation;
 
     /// Indicates whether this resolver can construct an audio source from the
     /// given descriptor.
@@ -95,199 +101,6 @@ impl Display for ResolveEffectError {
     }
 }
 
-struct ModifierParameterDocumentation {
-    name: String,
-    description: String
-}
-
-impl Display for ModifierParameterDocumentation {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "`{}`: {}", &self.name, &self.description)
-    }
-}
-
-/// Documentation of a modifier (effect or adapter) to be displayed to the user
-/// of the bot. The short form can be accessed by
-/// [ModifierDocumentation::short_summary] while a long markdown version is
-/// available behind the implementation of the [Display] trait.
-///
-/// To construct instances of this type, use the
-/// [ModifierDocumentationBuilder].
-pub struct ModifierDocumentation {
-    short_summary: String,
-    long_summary: String,
-    parameters: Vec<ModifierParameterDocumentation>
-}
-
-impl ModifierDocumentation {
-
-    /// Gets a short summary of the functionality of the documented modifier.
-    /// This is used for the overview page.
-    pub fn short_summary(&self) -> &str {
-        &self.short_summary
-    }
-}
-
-impl Display for ModifierDocumentation {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", &self.long_summary)?;
-
-        if self.parameters.is_empty() {
-            return Ok(());
-        }
-
-        writeln!(f)?;
-
-        for parameter in &self.parameters {
-            write!(f, "\n- {}", parameter)?;
-        }
-
-        Ok(())
-    }
-}
-
-/// A builder for [ModifierDocumentation]s. To construct a modifier
-/// documentation, create a new builder using
-/// [ModifierDocumentationBuilder::new], specify at least a short summary
-/// using [ModifierDocumentationBuilder::with_short_summary], and then build
-/// the final documentation using [ModifierDocumentationBuilder::build].
-/// Further information can be provided with other methods. You do not need to
-/// provide the effect/adapter name, as that is taken from context.
-///
-/// A simple usage example is shown below.
-///
-/// ```
-/// use rambot_api::ModifierDocumentationBuilder;
-///
-/// // Documentation for a volume effect
-///
-/// let doc = ModifierDocumentationBuilder::new()
-///     .with_short_summary("Controls the volume of a layer.")
-///     .with_long_summary(
-///         "Controls the volume of a layer by multiplying all audio with a \
-///         given factor.")
-///     .with_parameter("volume", "The factor by which audio is multiplied.")
-///     .build();
-/// ```
-pub struct ModifierDocumentationBuilder {
-    short_summary: Option<String>,
-    long_summary: Option<String>,
-    parameters: Vec<ModifierParameterDocumentation>
-}
-
-impl ModifierDocumentationBuilder {
-
-    /// Creates a new modifier documentation builder.
-    pub fn new() -> ModifierDocumentationBuilder {
-        ModifierDocumentationBuilder {
-            short_summary: None,
-            long_summary: None,
-            parameters: Vec::new()
-        }
-    }
-
-    /// Specify a short summary for this effect/adapter to be displayed in the
-    /// overview. If no long summary has been specified, it will be assigned to
-    /// the given short summary as well.
-    ///
-    /// # Arguments
-    ///
-    /// * `summary`: A short summary for this effect/adapter. Markdown is
-    /// supported.
-    ///
-    /// # Returns
-    ///
-    /// This builder after the operation. Useful for chaining.
-    pub fn with_short_summary<S>(mut self, summary: S)
-        -> ModifierDocumentationBuilder
-    where
-        S: Into<String>
-    {
-        let summary = summary.into();
-
-        self.long_summary.get_or_insert_with(|| summary.clone());
-        self.short_summary = Some(summary);
-        self
-    }
-
-    /// Specify a long summary for this effect/adapter to be displayed in the
-    /// effect/adapter specific help page.
-    ///
-    /// # Arguments
-    ///
-    /// * `summary`: A long summary for this effect/adapter. Markdown is
-    /// supported.
-    ///
-    /// # Returns
-    ///
-    /// This builder after the operation. Useful for chaining.
-    pub fn with_long_summary<S>(mut self, summary: S)
-        -> ModifierDocumentationBuilder
-    where
-        S: Into<String>
-    {
-        self.long_summary = Some(summary.into());
-        self
-    }
-
-    /// Adds a parameter documentation for a new parameter to the constructed
-    /// modifier documentation. To add multiple parameters, call this method
-    /// multiple times. The parameters will be displayed top-to-bottom in the
-    /// order this method is called.
-    ///
-    /// # Arguments
-    ///
-    /// * `name`: The name of the documented parameter.
-    /// * `description`: A description to be displayed for the documented
-    /// parameter.
-    ///
-    /// # Returns
-    ///
-    /// This builder after the operation. Useful for chaining.
-    pub fn with_parameter<S1, S2>(mut self, name: S1, description: S2)
-        -> ModifierDocumentationBuilder
-    where
-        S1: Into<String>,
-        S2: Into<String>
-    {
-        let name = name.into();
-        let description = description.into();
-
-        self.parameters.push(ModifierParameterDocumentation {
-            name,
-            description
-        });
-
-        self
-    }
-
-    /// Builds the modifier documentation constructed from the data provided
-    /// with previous method calls. At least
-    /// [ModifierDocumentationBuilder::with_short_summary] is required to be
-    /// called before this.
-    ///
-    /// # Returns
-    ///
-    /// `Some(_)` with a new [ModifierDocumentation] instance with the
-    /// previously provided information. If no short summary has been
-    /// specified, `None` is returned.
-    pub fn build(self) -> Option<ModifierDocumentation> {
-        self.short_summary
-            .and_then(|short| self.long_summary.map(|long| (short, long)))
-            .map(|(short_summary, long_summary)| ModifierDocumentation {
-                short_summary,
-                long_summary,
-                parameters: self.parameters
-            })
-    }
-}
-
-impl Default for ModifierDocumentationBuilder {
-    fn default() -> ModifierDocumentationBuilder {
-        ModifierDocumentationBuilder::new()
-    }
-}
-
 /// A trait for resolvers which can create effects from key-value arguments.
 /// Similarly to [AudioSourceResolver]s, these effects are realized as
 /// [AudioSource]s, however they receive a child audio source whose output can
@@ -341,6 +154,10 @@ pub trait EffectResolver : Send + Sync {
 /// descriptors. A plugin with the purpose of implementing new kinds of
 /// playlists will usually register at least one of these.
 pub trait AudioSourceListResolver : Send + Sync {
+
+    /// Constructs an [AudioDocumentation] for this kind of audio source list.
+    /// This is displayed when executing the audio command.
+    fn documentation(&self) -> AudioDocumentation;
 
     /// Indicates whether this resolver can construct an audio source list from
     /// the given descriptor.

--- a/rambot/src/command/mod.rs
+++ b/rambot/src/command/mod.rs
@@ -329,8 +329,7 @@ async fn audio(ctx: &Context, msg: &Message, audio: String)
     else {
         let audio_lower = audio.to_lowercase();
         let doc = plugin_manager.get_audio_documentations()
-            .filter(|d| d.name().to_lowercase() == audio_lower)
-            .next();
+            .find(|d| d.name().to_lowercase() == audio_lower);
 
         if let Some(doc) = doc {
             msg.reply(ctx, doc).await?;

--- a/rambot/src/command/mod.rs
+++ b/rambot/src/command/mod.rs
@@ -36,7 +36,7 @@ pub use effect::get_effect_commands;
 pub use layer::get_layer_commands;
 
 #[group]
-#[commands(connect, disconnect, cmd_do, play, skip, stop)]
+#[commands(audio, connect, disconnect, cmd_do, play, skip, stop)]
 struct Root;
 
 /// Gets a [CommandGroup] for the root commands (which are not part of any
@@ -298,6 +298,50 @@ async fn cmd_do(ctx: &Context, msg: &Message, commands: Vec<String>)
     Ok(None)
 }
 
+#[rambot_command(
+    description = "Lists all plugin-provided types of audio with a short \
+        summary. If an audio name is provided, a more detailed documentation \
+        page for that audio is displayed.",
+    usage = "[audio]",
+    rest
+)]
+async fn audio(ctx: &Context, msg: &Message, audio: String)
+        -> CommandResult<Option<String>> {
+    let data_guard = ctx.data.read().await;
+    let plugin_manager = data_guard.get::<PluginManager>().unwrap();
+
+    if audio.is_empty() {
+        let mut message = "Audio types:".to_owned();
+        let mut first = true;
+
+        for doc in plugin_manager.get_audio_documentations() {
+            if first {
+                writeln!(message).unwrap();
+                first = false;
+            }
+
+            write!(message, "\n- {}", doc.overview_entry()).unwrap();
+        }
+
+        msg.reply(ctx, message).await?;
+        Ok(None)
+    }
+    else {
+        let audio_lower = audio.to_lowercase();
+        let doc = plugin_manager.get_audio_documentations()
+            .filter(|d| d.name().to_lowercase() == audio_lower)
+            .next();
+
+        if let Some(doc) = doc {
+            msg.reply(ctx, doc).await?;
+            Ok(None)
+        }
+        else {
+            Ok(Some(format!("I found no audio of name {}.", audio)))
+        }
+    }
+}
+
 async fn list_layer_key_value_descriptors<F>(ctx: &Context, msg: &Message,
     layer: String, name_plural_capital: &str, get: F)
     -> CommandResult<Option<String>>
@@ -360,8 +404,7 @@ where
                 .unwrap();
         }
 
-        msg.reply(ctx, response)
-            .await?;
+        msg.reply(ctx, response).await?;
         Ok(None)
     }
 }

--- a/rambot/src/plugin.rs
+++ b/rambot/src/plugin.rs
@@ -9,7 +9,7 @@ use rambot_api::{
     EffectResolver,
     Plugin,
     PluginConfig,
-    ResolverRegistry, ModifierDocumentation
+    ResolverRegistry, ModifierDocumentation, AudioDocumentation
 };
 
 use serenity::prelude::TypeMapKey;
@@ -378,6 +378,16 @@ impl PluginManager {
                 Err(ResolveError::PluginResolveError(e)),
             _ => Ok(AudioDescriptorList::Single(descriptor.to_owned()))
         }
+    }
+
+    /// Gets an iterator over the [AudioDocumentation]s for all audio sources
+    /// and audio source lists provided by plugins.
+    pub fn get_audio_documentations(&self)
+            -> impl Iterator<Item = AudioDocumentation> + '_ {
+        self.audio_source_resolvers.iter()
+            .map(|r| r.documentation())
+            .chain(self.audio_source_list_resolvers.iter()
+                .map(|r| r.documentation()))
     }
 
     /// Gets an iterator over the names of all effects that have been


### PR DESCRIPTION
Added a way for plugins to provide documentation for their audio sources and audio source lists.
This can be accessed via the new `!audio` command.