### PR TITLE
SSE kernel convolutions

### DIFF
--- a/plugin-filters/src/kernel.rs
+++ b/plugin-filters/src/kernel.rs
@@ -38,6 +38,7 @@ unsafe fn sum_ps(mut a: __m128) -> f32 {
     _mm_cvtss_f32(a)
 }
 
+#[allow(unused_mut)] // if compiled without SSE, "mut" modifiers are unused
 fn fold(mut a: &[Sample], mut b: &[f32]) -> Sample {
     let mut sum = Sample::ZERO;
 

--- a/rambot-api/src/audio.rs
+++ b/rambot-api/src/audio.rs
@@ -1,8 +1,11 @@
 use std::io;
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 
-/// A single stereo audio sample in 32-bit float PCM format.
+/// A single stereo audio sample in 32-bit float PCM format. In memory, a
+/// a sample is laid out as the left channel (4 bytes) followed by the right
+/// channel (4 bytes) for a total of 8 bytes.
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(C)]
 pub struct Sample {
 
     /// The current amplitude on the left channel. Usually on a scale from -1


### PR DESCRIPTION
Kernel convolution filters now use SSE vector instructions, if available. This yields approximately a 100 % performance boost.