### PR TITLE
Plugin Config Files + Kernel Size + FFI Fix

### DIFF
--- a/plugin-commons/src/file.rs
+++ b/plugin-commons/src/file.rs
@@ -57,9 +57,9 @@ pub struct FileManager {
 impl FileManager {
 
     /// Creates a new file manager from the plugin `config`.
-    pub fn new(config: &PluginConfig) -> FileManager {
+    pub fn new(config: PluginConfig) -> FileManager {
         FileManager {
-            config: config.clone()
+            config
         }
     }
 

--- a/plugin-filters/Cargo.toml
+++ b/plugin-filters/Cargo.toml
@@ -10,3 +10,5 @@ crate-type = [ "cdylib" ]
 
 [dependencies]
 rambot-api = { path = "../rambot-api" }
+serde = { version = "1.0", features = [ "derive" ] }
+serde_json = "1.0"

--- a/plugin-filters/src/config.rs
+++ b/plugin-filters/src/config.rs
@@ -1,0 +1,45 @@
+use serde::{Deserialize, Serialize};
+
+use std::fs::{self, File};
+use std::path::Path;
+
+const DEFAULT_DEFAULT_GAUSSIAN_KERNEL_SIZE_SIGMAS: f32 = 5.0;
+
+#[derive(Clone, Deserialize, Serialize)]
+pub(crate) struct Config {
+    default_gaussian_kernel_size_sigmas: f32
+}
+
+impl Config {
+
+    pub(crate) fn load(path: &str) -> Result<Config, String> {
+        let path = Path::new(path);
+
+        if path.is_dir() {
+            Err("Config file is occupied by a directory.".to_owned())
+        }
+        else if path.is_file() {
+            let json = fs::read_to_string(path)
+                .map_err(|e| format!("Error reading config file: {}", e))?;
+                
+            Ok(serde_json::from_str(&json)
+                .map_err(|e| format!("Error reading config file: {}", e))?)
+        }
+        else {
+            let config = Config {
+                default_gaussian_kernel_size_sigmas:
+                    DEFAULT_DEFAULT_GAUSSIAN_KERNEL_SIZE_SIGMAS
+            };
+            let file = File::create(path)
+                .map_err(|e| format!("Error creating config file: {}", e))?;
+            serde_json::to_writer(file, &config)
+                .map_err(|e| format!("Error writing config file: {}", e))?;
+
+            Ok(config)
+        }
+    }
+
+    pub(crate) fn default_gaussian_kernel_size_sigmas(&self) -> f32 {
+        self.default_gaussian_kernel_size_sigmas
+    }
+}

--- a/plugin-filters/src/kernel.rs
+++ b/plugin-filters/src/kernel.rs
@@ -130,12 +130,10 @@ impl AudioSource for KernelFilter {
     }
 }
 
-const KERNEL_SIZE_STD_DEVIATIONS: f32 = 5.0;
 const SQRT_TAU: f32 = (2.0 / consts::FRAC_2_SQRT_PI) * consts::SQRT_2;
 
-pub(crate) fn gaussian(sigma: f32) -> Vec<f32> {
-    let kernel_size =
-        (KERNEL_SIZE_STD_DEVIATIONS * sigma).ceil() as usize * 2 + 1;
+pub(crate) fn gaussian(sigma: f32, kernel_size_sigmas: f32) -> Vec<f32> {
+    let kernel_size = (kernel_size_sigmas * sigma).ceil() as usize * 2 + 1;
     let mut kernel = Vec::with_capacity(kernel_size);
     let mid_point = (kernel_size / 2) as isize;
 
@@ -148,8 +146,8 @@ pub(crate) fn gaussian(sigma: f32) -> Vec<f32> {
     kernel
 }
 
-pub(crate) fn inv_gaussian(sigma: f32) -> Vec<f32> {
-    let mut kernel = gaussian(sigma);
+pub(crate) fn inv_gaussian(sigma: f32, kernel_size_sigmas: f32) -> Vec<f32> {
+    let mut kernel = gaussian(sigma, kernel_size_sigmas);
 
     for f in kernel.iter_mut() {
         *f = -*f;

--- a/plugin-flac/src/lib.rs
+++ b/plugin-flac/src/lib.rs
@@ -171,7 +171,7 @@ struct FlacPlugin;
 
 impl Plugin for FlacPlugin {
 
-    fn load_plugin<'registry>(&mut self, config: &PluginConfig,
+    fn load_plugin<'registry>(&self, config: PluginConfig,
             registry: &mut ResolverRegistry<'registry>) -> Result<(), String> {
         registry.register_audio_source_resolver(FlacAudioSourceResolver {
             file_manager: FileManager::new(config)

--- a/plugin-folder-list/src/lib.rs
+++ b/plugin-folder-list/src/lib.rs
@@ -74,7 +74,7 @@ struct FolderListPlugin;
 
 impl Plugin for FolderListPlugin {
 
-    fn load_plugin<'registry>(&mut self, config: &PluginConfig,
+    fn load_plugin<'registry>(&self, config: PluginConfig,
             registry: &mut ResolverRegistry<'registry>) -> Result<(), String> {
         registry.register_audio_source_list_resolver(FolderListResolver {
             root: config.root_directory().to_owned()

--- a/plugin-json-list/src/lib.rs
+++ b/plugin-json-list/src/lib.rs
@@ -83,7 +83,7 @@ struct JsonListPlugin;
 
 impl Plugin for JsonListPlugin {
 
-    fn load_plugin<'registry>(&mut self, config: &PluginConfig,
+    fn load_plugin<'registry>(&self, config: PluginConfig,
             registry: &mut ResolverRegistry<'registry>) -> Result<(), String> {
         registry.register_audio_source_list_resolver(
             JsonAudioSourceListResolver {

--- a/plugin-loop/src/lib.rs
+++ b/plugin-loop/src/lib.rs
@@ -67,7 +67,7 @@ struct LoopPlugin;
 
 impl Plugin for LoopPlugin {
 
-    fn load_plugin<'registry>(&mut self, _config: &PluginConfig,
+    fn load_plugin<'registry>(&self, _config: PluginConfig,
             registry: &mut ResolverRegistry<'registry>) -> Result<(), String> {
         registry.register_adapter_resolver(LoopAdapterResolver);
         Ok(())
@@ -79,4 +79,3 @@ fn make_loop_plugin() -> LoopPlugin {
 }
 
 rambot_api::export_plugin!(make_loop_plugin);
-

--- a/plugin-mp3/src/lib.rs
+++ b/plugin-mp3/src/lib.rs
@@ -164,7 +164,7 @@ struct Mp3Plugin;
 
 impl Plugin for Mp3Plugin {
 
-    fn load_plugin<'registry>(&mut self, config: &PluginConfig,
+    fn load_plugin<'registry>(&self, config: PluginConfig,
             registry: &mut ResolverRegistry<'registry>) -> Result<(), String> {
         registry.register_audio_source_resolver(Mp3AudioSourceResolver {
             file_manager: FileManager::new(config)

--- a/plugin-ogg/src/lib.rs
+++ b/plugin-ogg/src/lib.rs
@@ -150,7 +150,7 @@ struct OggPlugin;
 
 impl Plugin for OggPlugin {
 
-    fn load_plugin<'registry>(&mut self, config: &PluginConfig,
+    fn load_plugin<'registry>(&self, config: PluginConfig,
             registry: &mut ResolverRegistry<'registry>) -> Result<(), String> {
         registry.register_audio_source_resolver(OggAudioSourceResolver {
             file_manager: FileManager::new(config)

--- a/plugin-shuffle/src/lib.rs
+++ b/plugin-shuffle/src/lib.rs
@@ -90,7 +90,7 @@ impl AdapterResolver for ShuffleAdapterResolver {
 struct ShufflePlugin;
 
 impl Plugin for ShufflePlugin {
-    fn load_plugin<'registry>(&mut self, _config: &PluginConfig,
+    fn load_plugin<'registry>(&self, _config: PluginConfig,
             registry: &mut ResolverRegistry<'registry>) -> Result<(), String> {
         registry.register_adapter_resolver(ShuffleAdapterResolver);
         Ok(())

--- a/plugin-volume/src/lib.rs
+++ b/plugin-volume/src/lib.rs
@@ -85,7 +85,7 @@ impl EffectResolver for VolumeEffectResolver {
 struct VolumePlugin;
 
 impl Plugin for VolumePlugin {
-    fn load_plugin<'registry>(&mut self, _config: &PluginConfig,
+    fn load_plugin<'registry>(&self, _config: PluginConfig,
             registry: &mut ResolverRegistry<'registry>) -> Result<(), String> {
         registry.register_effect_resolver(VolumeEffectResolver);
         Ok(())

--- a/plugin-wave/src/lib.rs
+++ b/plugin-wave/src/lib.rs
@@ -226,7 +226,7 @@ impl AudioSourceResolver for WaveAudioSourceResolver {
 struct WavePlugin;
 
 impl Plugin for WavePlugin {
-    fn load_plugin<'registry>(&mut self, config: &PluginConfig,
+    fn load_plugin<'registry>(&self, config: PluginConfig,
             registry: &mut ResolverRegistry<'registry>) -> Result<(), String> {
         registry.register_audio_source_resolver(WaveAudioSourceResolver {
             file_manager: FileManager::new(config)

--- a/rambot-api/Cargo.toml
+++ b/rambot-api/Cargo.toml
@@ -6,4 +6,3 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = { version = "1.0", features = [ "derive" ] }


### PR DESCRIPTION
Implemented a mechanism to allow plugins to manage their own config files in a safe way.
Added an optional `kernel_size` parameter for the `gaussian` and `inv_gaussian` filters whose default value is provided in a plugin config file.
Fixed an FFI issue with passing the plugin trait object that caused weird (and possibly undefined) behavior.
This resolves #98 