### PR TITLE
Guild-specific directory

### DIFF
--- a/plugin-commons/src/file.rs
+++ b/plugin-commons/src/file.rs
@@ -76,7 +76,7 @@ impl FileManager {
             guild_config: &PluginGuildConfig) -> Option<ResolvedFile> {
         let root_directory = guild_config.root_directory()
             .map(|s| s.as_str())
-            .unwrap_or(self.config.root_directory());
+            .unwrap_or_else(|| self.config.root_directory());
         let path = Path::new(root_directory).join(file);
 
         if path.as_path().exists() {

--- a/plugin-filters/src/lib.rs
+++ b/plugin-filters/src/lib.rs
@@ -12,6 +12,7 @@ use rambot_api::{
     ModifierDocumentationBuilder,
     Plugin,
     PluginConfig,
+    PluginGuildConfig,
     ResolveEffectError,
     ResolverRegistry
 };
@@ -97,7 +98,8 @@ impl EffectResolver for GaussianEffectResolver {
     }
 
     fn resolve(&self, key_values: &HashMap<String, String>,
-            child: Box<dyn AudioSource + Send>)
+            child: Box<dyn AudioSource + Send>,
+            _guild_config: PluginGuildConfig)
             -> Result<Box<dyn AudioSource + Send>, ResolveEffectError> {
         resolve_gaussian_like_kernel_filter(
             key_values, child, &self.config, kernel::gaussian)
@@ -131,7 +133,8 @@ impl EffectResolver for InvGaussianEffectResolver {
     }
 
     fn resolve(&self, key_values: &HashMap<String, String>,
-            child: Box<dyn AudioSource + Send>)
+            child: Box<dyn AudioSource + Send>,
+            _plugin_guild_config: PluginGuildConfig)
             -> Result<Box<dyn AudioSource + Send>, ResolveEffectError> {
         resolve_gaussian_like_kernel_filter(
             key_values, child, &self.config, kernel::inv_gaussian)

--- a/plugin-flac/src/lib.rs
+++ b/plugin-flac/src/lib.rs
@@ -14,6 +14,7 @@ use rambot_api::{
     AudioSourceResolver,
     Plugin,
     PluginConfig,
+    PluginGuildConfig,
     ResolverRegistry,
     Sample
 };
@@ -152,13 +153,15 @@ impl AudioSourceResolver for FlacAudioSourceResolver {
             .build().unwrap()
     }
 
-    fn can_resolve(&self, descriptor: &str) -> bool {
-        self.file_manager.is_file_with_extension(descriptor, ".flac")
+    fn can_resolve(&self, descriptor: &str, guild_config: PluginGuildConfig)
+            -> bool {
+        self.file_manager.is_file_with_extension(
+            descriptor, &guild_config, ".flac")
     }
 
-    fn resolve(&self, descriptor: &str)
+    fn resolve(&self, descriptor: &str, guild_config: PluginGuildConfig)
             -> Result<Box<dyn AudioSource + Send>, String> {
-        let file = self.file_manager.open_file_buf(descriptor)?;
+        let file = self.file_manager.open_file_buf(descriptor, &guild_config)?;
 
         match file {
             OpenedFile::Local(reader) => self.resolve_reader(reader),

--- a/plugin-json-list/src/lib.rs
+++ b/plugin-json-list/src/lib.rs
@@ -10,6 +10,7 @@ use rambot_api::{
     AudioSourceListResolver,
     Plugin,
     PluginConfig,
+    PluginGuildConfig,
     ResolverRegistry
 };
 
@@ -64,13 +65,15 @@ impl AudioSourceListResolver for JsonAudioSourceListResolver {
             .build().unwrap()
     }
 
-    fn can_resolve(&self, descriptor: &str) -> bool {
-        self.file_manager.is_file_with_extension(descriptor, ".json")
+    fn can_resolve(&self, descriptor: &str,
+            guild_config: PluginGuildConfig) -> bool {
+        self.file_manager.is_file_with_extension(
+            descriptor, &guild_config, ".json")
     }
 
-    fn resolve(&self, descriptor: &str)
+    fn resolve(&self, descriptor: &str, guild_config: PluginGuildConfig)
             -> Result<Box<dyn AudioSourceList + Send>, String> {
-        let file = self.file_manager.open_file_buf(descriptor)?;
+        let file = self.file_manager.open_file_buf(descriptor, &guild_config)?;
 
         match file {
             OpenedFile::Local(reader) => self.resolve_reader(reader),

--- a/plugin-loop/src/lib.rs
+++ b/plugin-loop/src/lib.rs
@@ -5,6 +5,7 @@ use rambot_api::{
     ModifierDocumentationBuilder,
     Plugin,
     PluginConfig,
+    PluginGuildConfig,
     ResolverRegistry
 };
 
@@ -53,7 +54,8 @@ impl AdapterResolver for LoopAdapterResolver {
     }
 
     fn resolve(&self, _key_values: &HashMap<String, String>,
-            child: Box<dyn AudioSourceList + Send>)
+            child: Box<dyn AudioSourceList + Send>,
+            _guild_config: PluginGuildConfig)
             -> Result<Box<dyn AudioSourceList + Send>, String> {
         Ok(Box::new(LoopAudioSourceList {
             child,

--- a/plugin-mp3/src/lib.rs
+++ b/plugin-mp3/src/lib.rs
@@ -9,6 +9,7 @@ use rambot_api::{
     AudioSourceResolver,
     Plugin,
     PluginConfig,
+    PluginGuildConfig,
     ResolverRegistry,
     Sample
 };
@@ -145,13 +146,15 @@ impl AudioSourceResolver for Mp3AudioSourceResolver {
             .build().unwrap()
     }
 
-    fn can_resolve(&self, descriptor: &str) -> bool {
-        self.file_manager.is_file_with_extension(descriptor, ".mp3")
+    fn can_resolve(&self, descriptor: &str, guild_config: PluginGuildConfig)
+            -> bool {
+        self.file_manager.is_file_with_extension(
+            descriptor, &guild_config, ".mp3")
     }
 
-    fn resolve(&self, descriptor: &str)
+    fn resolve(&self, descriptor: &str, guild_config: PluginGuildConfig)
             -> Result<Box<dyn AudioSource + Send>, String> {
-        let file = self.file_manager.open_file_buf(descriptor)?;
+        let file = self.file_manager.open_file_buf(descriptor, &guild_config)?;
     
         match file {
             OpenedFile::Local(reader) => self.resolve_reader(reader),

--- a/plugin-ogg/src/lib.rs
+++ b/plugin-ogg/src/lib.rs
@@ -10,6 +10,7 @@ use rambot_api::{
     ResolverRegistry,
     Plugin,
     PluginConfig,
+    PluginGuildConfig,
     Sample
 };
 
@@ -130,13 +131,15 @@ impl AudioSourceResolver for OggAudioSourceResolver {
             .build().unwrap()
     }
 
-    fn can_resolve(&self, descriptor: &str) -> bool {
-        self.file_manager.is_file_with_extension(descriptor, ".ogg")
+    fn can_resolve(&self, descriptor: &str, guild_config: PluginGuildConfig)
+            -> bool {
+        self.file_manager.is_file_with_extension(
+            descriptor, &guild_config, ".ogg")
     }
 
-    fn resolve(&self, descriptor: &str)
+    fn resolve(&self, descriptor: &str, guild_config: PluginGuildConfig)
             -> Result<Box<dyn AudioSource + Send>, String> {
-        let file = self.file_manager.open_file_buf(descriptor)?;
+        let file = self.file_manager.open_file_buf(descriptor, &guild_config)?;
     
         match file {
             OpenedFile::Local(reader) => self.resolve_reader(reader),

--- a/plugin-shuffle/src/lib.rs
+++ b/plugin-shuffle/src/lib.rs
@@ -5,6 +5,7 @@ use rambot_api::{
     ModifierDocumentationBuilder,
     Plugin,
     PluginConfig,
+    PluginGuildConfig,
     ResolverRegistry
 };
 
@@ -76,7 +77,8 @@ impl AdapterResolver for ShuffleAdapterResolver {
     }
 
     fn resolve(&self, _key_values: &HashMap<String, String>,
-            child: Box<dyn AudioSourceList + Send>)
+            child: Box<dyn AudioSourceList + Send>,
+            _guild_config: PluginGuildConfig)
             -> Result<Box<dyn AudioSourceList + Send>, String> {
         Ok(Box::new(ShuffleAudioSourceList {
             child,

--- a/plugin-volume/src/lib.rs
+++ b/plugin-volume/src/lib.rs
@@ -5,6 +5,7 @@ use rambot_api::{
     ModifierDocumentationBuilder,
     Plugin,
     PluginConfig,
+    PluginGuildConfig,
     ResolveEffectError,
     ResolverRegistry,
     Sample
@@ -68,7 +69,8 @@ impl EffectResolver for VolumeEffectResolver {
     }
 
     fn resolve(&self, key_values: &HashMap<String, String>,
-            child: Box<dyn AudioSource + Send>)
+            child: Box<dyn AudioSource + Send>,
+            _guild_config: PluginGuildConfig)
             -> Result<Box<dyn AudioSource + Send>, ResolveEffectError> {
         let volume = match get_volume(key_values) {
             Ok(v) => v,

--- a/plugin-wave/src/lib.rs
+++ b/plugin-wave/src/lib.rs
@@ -11,6 +11,7 @@ use rambot_api::{
     AudioSourceResolver,
     Plugin,
     PluginConfig,
+    PluginGuildConfig,
     ResolverRegistry,
     Sample
 };
@@ -208,13 +209,15 @@ impl AudioSourceResolver for WaveAudioSourceResolver {
             .build().unwrap()
     }
 
-    fn can_resolve(&self, descriptor: &str) -> bool {
-        self.file_manager.is_file_with_extension(descriptor, ".wav")
+    fn can_resolve(&self, descriptor: &str, guild_config: PluginGuildConfig)
+            -> bool {
+        self.file_manager.is_file_with_extension(
+            descriptor, &guild_config, ".wav")
     }
 
-    fn resolve(&self, descriptor: &str)
+    fn resolve(&self, descriptor: &str, guild_config: PluginGuildConfig)
             -> Result<Box<dyn AudioSource + Send>, String> {
-        let file = self.file_manager.open_file_buf(descriptor)?;
+        let file = self.file_manager.open_file_buf(descriptor, &guild_config)?;
 
         match file {
             OpenedFile::Local(reader) => self.resolve_reader(reader),

--- a/rambot-api/src/lib.rs
+++ b/rambot-api/src/lib.rs
@@ -133,7 +133,7 @@ impl PluginConfig {
 }
 
 /// Guild-specific configuration provided to a plugin's resolvers.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct PluginGuildConfig {
     root_directory: Option<String>
 }
@@ -160,14 +160,6 @@ impl PluginGuildConfig {
     /// used if this method returns `None`.
     pub fn root_directory(&self) -> Option<&String> {
         self.root_directory.as_ref()
-    }
-}
-
-impl Default for PluginGuildConfig {
-    fn default() -> PluginGuildConfig {
-        PluginGuildConfig {
-            root_directory: None
-        }
     }
 }
 

--- a/rambot-api/src/lib.rs
+++ b/rambot-api/src/lib.rs
@@ -77,7 +77,7 @@ pub use resolver::{
 /// plugin, but not the bot itself. It is passed to the plugin during
 /// initialization. It is the plugin's responsibility to act according to this
 /// config.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PluginConfig {
     root_directory: String,
     allow_web_access: bool,
@@ -129,6 +129,45 @@ impl PluginConfig {
     /// exist.
     pub fn config_path(&self) -> &str {
         &self.config_path
+    }
+}
+
+/// Guild-specific configuration provided to a plugin's resolvers.
+#[derive(Clone, Debug)]
+pub struct PluginGuildConfig {
+    root_directory: Option<String>
+}
+
+impl PluginGuildConfig {
+
+    /// Creates a new plugin guild config from the given data.
+    ///
+    /// # Arguments
+    ///
+    /// * `root_directory`: The guild-specific root directory or `None` if the
+    /// global root directory should be used.
+    pub fn new<S>(root_directory: Option<S>) -> PluginGuildConfig
+    where
+        S: Into<String>
+    {
+        PluginGuildConfig {
+            root_directory: root_directory.map(|s| s.into())
+        }
+    }
+
+    /// Gets the guild-specific root directory to use for file system accesses.
+    /// If present, this overrides the global root directory, which should be
+    /// used if this method returns `None`.
+    pub fn root_directory(&self) -> Option<&String> {
+        self.root_directory.as_ref()
+    }
+}
+
+impl Default for PluginGuildConfig {
+    fn default() -> PluginGuildConfig {
+        PluginGuildConfig {
+            root_directory: None
+        }
     }
 }
 

--- a/rambot-api/src/resolver.rs
+++ b/rambot-api/src/resolver.rs
@@ -21,6 +21,7 @@ use std::fmt::{self, Display, Formatter};
 ///     AudioDocumentationBuilder,
 ///     AudioSource,
 ///     AudioSourceResolver,
+///     PluginGuildConfig,
 ///     Sample
 /// };
 /// 
@@ -87,14 +88,14 @@ use std::fmt::{self, Display, Formatter};
 ///             .build().unwrap()
 ///     }
 /// 
-///     fn can_resolve(&self, descriptor: &str) -> bool {
+///     fn can_resolve(&self, descriptor: &str, _: PluginGuildConfig) -> bool {
 ///         // In this function, we get a user-provided audio descriptor and
 ///         // have to determine whether this resolver can build an audio
 ///         // source from it.
 ///         sine_regex().is_match(descriptor)
 ///     }
 /// 
-///     fn resolve(&self, descriptor: &str)
+///     fn resolve(&self, descriptor: &str, _: PluginGuildConfig)
 ///             -> Result<Box<dyn AudioSource + Send>, String> {
 ///         // Here we actually have to construct the audio source from the
 ///         // descriptor. We can rely on "can_resolve" to be true for the
@@ -224,6 +225,7 @@ impl Display for ResolveEffectError {
 ///     EffectResolver,
 ///     ModifierDocumentation,
 ///     ModifierDocumentationBuilder,
+///     PluginGuildConfig,
 ///     ResolveEffectError,
 ///     Sample
 /// };
@@ -309,7 +311,7 @@ impl Display for ResolveEffectError {
 ///     }
 ///     
 ///     fn resolve(&self, key_values: &HashMap<String, String>,
-///             child: Box<dyn AudioSource + Send>)
+///             child: Box<dyn AudioSource + Send>, _: PluginGuildConfig)
 ///             -> Result<Box<dyn AudioSource + Send>, ResolveEffectError> {
 ///         // Here we actually have to construct the effect from the
 ///         // key-value-pairs parsed by the bot. We get the child to which we
@@ -385,7 +387,8 @@ pub trait EffectResolver : Send + Sync {
 ///     AudioDocumentation,
 ///     AudioDocumentationBuilder,
 ///     AudioSourceList,
-///     AudioSourceListResolver
+///     AudioSourceListResolver,
+///     PluginGuildConfig
 /// };
 /// 
 /// use std::io;
@@ -438,14 +441,14 @@ pub trait EffectResolver : Send + Sync {
 ///             .build().unwrap()
 ///     }
 ///     
-///     fn can_resolve(&self, descriptor: &str) -> bool {
+///     fn can_resolve(&self, descriptor: &str, _: PluginGuildConfig) -> bool {
 ///         // As with AudioSourceResolvers, we get a user-provided audio
 ///         // descriptor and have to determine whether this resolver can build
 ///         // an audio source list from it.
 ///         resolve_list(descriptor).is_some()
 ///     }
 ///     
-///     fn resolve(&self, descriptor: &str)
+///     fn resolve(&self, descriptor: &str, _: PluginGuildConfig)
 ///             -> Result<Box<dyn AudioSourceList + Send>, String> {
 ///         // As with AudioSourceResolvers, here we actually have to construct
 ///         // the audio source list from the descriptor. We can rely on
@@ -525,7 +528,8 @@ pub trait AudioSourceListResolver : Send + Sync {
 ///     AdapterResolver,
 ///     AudioSourceList,
 ///     ModifierDocumentation,
-///     ModifierDocumentationBuilder
+///     ModifierDocumentationBuilder,
+///     PluginGuildConfig
 /// };
 /// 
 /// use std::collections::HashMap;
@@ -589,7 +593,7 @@ pub trait AudioSourceListResolver : Send + Sync {
 ///     }
 ///     
 ///     fn resolve(&self, _key_values: &HashMap<String, String>,
-///             child: Box<dyn AudioSourceList + Send>)
+///             child: Box<dyn AudioSourceList + Send>, _: PluginGuildConfig)
 ///             -> Result<Box<dyn AudioSourceList + Send>, String> {
 ///         // Here we actually have to construct the effect from the
 ///         // key-value-pairs parsed by the bot. We get the child to which we

--- a/rambot-api/src/resolver.rs
+++ b/rambot-api/src/resolver.rs
@@ -1,4 +1,4 @@
-use crate::AudioDocumentation;
+use crate::{AudioDocumentation, PluginGuildConfig};
 use crate::audio::{AudioSource, AudioSourceList};
 use crate::documentation::ModifierDocumentation;
 
@@ -125,12 +125,15 @@ pub trait AudioSourceResolver : Send + Sync {
     /// # Arguments
     ///
     /// * `descriptor`: A textual descriptor of unspecified format.
+    /// * `guild_config`: A [PluginGuildConfig] containing guild-specific
+    /// information that may be relevant to the resolution.
     ///
     /// # Returns
     ///
     /// True, if and only if this resolver can construct an audio source from
     /// the given descriptor.
-    fn can_resolve(&self, descriptor: &str) -> bool;
+    fn can_resolve(&self, descriptor: &str, guild_config: PluginGuildConfig)
+        -> bool;
 
     /// Generates an [AudioSource] trait object from the given descriptor. If
     /// [AudioSourceResolver::can_resolve] returns `true`, this should probably
@@ -146,6 +149,8 @@ pub trait AudioSourceResolver : Send + Sync {
     /// # Arguments
     ///
     /// * `descriptor`: A textual descriptor of unspecified format.
+    /// * `guild_config`: A [PluginGuildConfig] containing guild-specific
+    /// information that may be relevant to the resolution.
     ///
     /// # Returns
     ///
@@ -155,7 +160,7 @@ pub trait AudioSourceResolver : Send + Sync {
     /// # Errors
     ///
     /// An error message provided as a [String] in case resolution fails.
-    fn resolve(&self, descriptor: &str)
+    fn resolve(&self, descriptor: &str, guild_config: PluginGuildConfig)
         -> Result<Box<dyn AudioSource + Send>, String>;
 }
 
@@ -350,6 +355,8 @@ pub trait EffectResolver : Send + Sync {
     /// as the argument value.
     /// * `child`: A boxed [AudioSource] to which the effect shall be applied,
     /// i.e. which should be wrapped in an effect audio source.
+    /// * `guild_config`: A [PluginGuildConfig] containing guild-specific
+    /// information that may be relevant to the resolution.
     ///
     /// # Returns
     ///
@@ -362,7 +369,7 @@ pub trait EffectResolver : Send + Sync {
     /// A [ResolveEffectError] containing an error message as well as the given
     /// `child` in case resolution fails.
     fn resolve(&self, key_values: &HashMap<String, String>,
-        child: Box<dyn AudioSource + Send>)
+        child: Box<dyn AudioSource + Send>, guild_config: PluginGuildConfig)
         -> Result<Box<dyn AudioSource + Send>, ResolveEffectError>;
 }
 
@@ -464,12 +471,15 @@ pub trait AudioSourceListResolver : Send + Sync {
     /// # Arguments
     ///
     /// * `descriptor`: A textual descriptor of unspecified format.
+    /// * `guild_config`: A [PluginGuildConfig] containing guild-specific
+    /// information that may be relevant to the resolution.
     ///
     /// # Returns
     ///
     /// True, if and only if this resolver can construct an audio source list
     /// from the given descriptor.
-    fn can_resolve(&self, descriptor: &str) -> bool;
+    fn can_resolve(&self, descriptor: &str, guild_config: PluginGuildConfig)
+        -> bool;
 
     /// Generates an [AudioSourceList] trait object from the given descriptor.
     /// If [AudioSourceListResolver::can_resolve] returns `true`, this should
@@ -485,6 +495,8 @@ pub trait AudioSourceListResolver : Send + Sync {
     /// # Arguments
     ///
     /// * `descriptor`: A textual descriptor of unspecified format.
+    /// * `guild_config`: A [PluginGuildConfig] containing guild-specific
+    /// information that may be relevant to the resolution.
     ///
     /// # Returns
     ///
@@ -494,7 +506,7 @@ pub trait AudioSourceListResolver : Send + Sync {
     /// # Errors
     ///
     /// An error message provided as a [String] in case resolution fails.
-    fn resolve(&self, descriptor: &str)
+    fn resolve(&self, descriptor: &str, guild_config: PluginGuildConfig)
         -> Result<Box<dyn AudioSourceList + Send>, String>;
 }
 
@@ -621,6 +633,8 @@ pub trait AdapterResolver : Send + Sync {
     /// given as the argument value.
     /// * `child`: A boxed [AudioSourceList] to which the adapter shall be
     /// applied, i.e. which should be wrapped in an adapter audio source list.
+    /// * `guild_config`: A [PluginGuildConfig] containing guild-specific
+    /// information that may be relevant to the resolution.
     ///
     /// # Returns
     ///
@@ -631,7 +645,8 @@ pub trait AdapterResolver : Send + Sync {
     ///
     /// An error message provided as a [String] in case resolution fails.
     fn resolve(&self, key_values: &HashMap<String, String>,
-        child: Box<dyn AudioSourceList + Send>)
+        child: Box<dyn AudioSourceList + Send>,
+        guild_config: PluginGuildConfig)
         -> Result<Box<dyn AudioSourceList + Send>, String>;
 }
 

--- a/rambot/src/config.rs
+++ b/rambot/src/config.rs
@@ -2,6 +2,7 @@ use rambot_api::PluginConfig;
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
+use serenity::model::prelude::UserId;
 use serenity::prelude::TypeMapKey;
 
 use simplelog::LevelFilter;
@@ -121,6 +122,7 @@ where
 pub struct Config {
     prefix: String,
     token: String,
+    owners: Vec<UserId>,
     plugin_directory: String,
     plugin_config_directory: String,
     state_directory: String,
@@ -160,6 +162,7 @@ impl Config {
             let config = Config {
                 prefix: DEFAULT_PREFIX.to_owned(),
                 token,
+                owners: Vec::new(),
                 plugin_directory: DEFAULT_PLUGIN_DIRECTORY.to_owned(),
                 plugin_config_directory:
                     DEFAULT_PLUGIN_CONFIG_DIRECTORY.to_owned(),
@@ -170,6 +173,10 @@ impl Config {
             };
             let file = File::create(path)?;
             serde_json::to_writer(file, &config)?;
+
+            log::info!("New config file successfully created.");
+            log::info!("If you want to use owner-only commands, specify the \
+                owners' user IDs in the config file.");
 
             Ok(config)
         }
@@ -183,6 +190,12 @@ impl Config {
     /// The Discord API token that the bot uses to connect to Discord.
     pub fn token(&self) -> &str {
         &self.token
+    }
+
+    /// A slice of the [UserId]s of all Discord users that can act as owners of
+    /// this bot, i.e. execute commands marked as `owner_only`.
+    pub fn owners(&self) -> &[UserId] {
+        &self.owners
     }
 
     /// The path of the directory from which the bot shall load its plugins.

--- a/rambot/src/main.rs
+++ b/rambot/src/main.rs
@@ -116,7 +116,9 @@ async fn main() {
 
     let framework: FrameworkArc =
         Arc::new(Box::new(StandardFramework::new()
-            .configure(|c| c.prefix(config.prefix()))
+            .configure(|c| c
+                .prefix(config.prefix())
+                .owners(config.owners().iter().cloned().collect()))
             .group(command::get_root_commands())
             .group(command::get_adapter_commands())
             .group(command::get_board_commands())


### PR DESCRIPTION
Added the `!directory` command which allows specifying a root directory to be used for file system accesses only on the guild where the command was executed. This command is restricted to owners, which is a new field added to the config.