### PR TITLE
RW Locking for Guild States

### DIFF
--- a/plugin-commons/src/audio.rs
+++ b/plugin-commons/src/audio.rs
@@ -113,7 +113,7 @@ impl<S: AudioSource> AudioSource for ResamplingAudioSource<S> {
         self.base.has_child()
     }
 
-    fn take_child(&mut self) -> Box<dyn AudioSource + Send> {
+    fn take_child(&mut self) -> Box<dyn AudioSource + Send + Sync> {
         Box::new(ResamplingAudioSource {
             base: self.base.take_child(),
             buf: mem::take(&mut self.buf),
@@ -140,9 +140,9 @@ const TARGET_SAMPLING_RATE_USIZE: usize = TARGET_SAMPLING_RATE as usize;
 ///
 /// A boxed audio source which has a sampling rate of 48 kHz.
 pub fn adapt_sampling_rate<S>(audio_source: S, sampling_rate: u32)
-    -> Box<dyn AudioSource + Send>
+    -> Box<dyn AudioSource + Send + Sync>
 where
-    S: AudioSource + Send + 'static
+    S: AudioSource + Send + Sync + 'static
 {
     if sampling_rate == TARGET_SAMPLING_RATE {
         Box::new(audio_source)

--- a/plugin-filters/src/kernel.rs
+++ b/plugin-filters/src/kernel.rs
@@ -86,7 +86,7 @@ pub(crate) struct KernelFilter {
 }
 
 impl KernelFilter {
-    pub(crate) fn new(child: Box<dyn AudioSource + Send>, kernel: Vec<f32>)
+    pub(crate) fn new(child: Box<dyn AudioSource + Send + Sync>, kernel: Vec<f32>)
             -> KernelFilter {
         let padding = kernel.len() - 1;
         let child = RightPaddedAudioSource::new(child, padding);
@@ -125,7 +125,7 @@ impl AudioSource for KernelFilter {
         true
     }
 
-    fn take_child(&mut self) -> Box<dyn AudioSource + Send> {
+    fn take_child(&mut self) -> Box<dyn AudioSource + Send + Sync> {
         self.child.take_child()
     }
 }

--- a/plugin-filters/src/lib.rs
+++ b/plugin-filters/src/lib.rs
@@ -36,8 +36,8 @@ fn get_kernel_size_sigmas(key_values: &HashMap<String, String>, config: &Config)
 }
 
 fn resolve_gaussian_like_kernel_filter<F>(key_values: &HashMap<String, String>,
-    child: Box<dyn AudioSource + Send>, config: &Config, gen_kernel: F)
-    -> Result<Box<dyn AudioSource + Send>, ResolveEffectError>
+    child: Box<dyn AudioSource + Send + Sync>, config: &Config, gen_kernel: F)
+    -> Result<Box<dyn AudioSource + Send + Sync>, ResolveEffectError>
 where
     F: Fn(f32, f32) -> Vec<f32>
 {
@@ -98,9 +98,9 @@ impl EffectResolver for GaussianEffectResolver {
     }
 
     fn resolve(&self, key_values: &HashMap<String, String>,
-            child: Box<dyn AudioSource + Send>,
+            child: Box<dyn AudioSource + Send + Sync>,
             _guild_config: PluginGuildConfig)
-            -> Result<Box<dyn AudioSource + Send>, ResolveEffectError> {
+            -> Result<Box<dyn AudioSource + Send + Sync>, ResolveEffectError> {
         resolve_gaussian_like_kernel_filter(
             key_values, child, &self.config, kernel::gaussian)
     }
@@ -133,9 +133,9 @@ impl EffectResolver for InvGaussianEffectResolver {
     }
 
     fn resolve(&self, key_values: &HashMap<String, String>,
-            child: Box<dyn AudioSource + Send>,
+            child: Box<dyn AudioSource + Send + Sync>,
             _plugin_guild_config: PluginGuildConfig)
-            -> Result<Box<dyn AudioSource + Send>, ResolveEffectError> {
+            -> Result<Box<dyn AudioSource + Send + Sync>, ResolveEffectError> {
         resolve_gaussian_like_kernel_filter(
             key_values, child, &self.config, kernel::inv_gaussian)
     }

--- a/plugin-filters/src/util.rs
+++ b/plugin-filters/src/util.rs
@@ -4,12 +4,12 @@ use std::io;
 
 pub(crate) struct RightPaddedAudioSource {
     padding: usize,
-    child: Option<Box<dyn AudioSource + Send>>,
+    child: Option<Box<dyn AudioSource + Send + Sync>>,
     child_finished: bool
 }
 
 impl RightPaddedAudioSource {
-    pub(crate) fn new(child: Box<dyn AudioSource + Send>, padding: usize)
+    pub(crate) fn new(child: Box<dyn AudioSource + Send + Sync>, padding: usize)
             -> RightPaddedAudioSource {
         RightPaddedAudioSource {
             padding,
@@ -43,7 +43,7 @@ impl AudioSource for RightPaddedAudioSource {
         true
     }
 
-    fn take_child(&mut self) -> Box<dyn AudioSource + Send> {
+    fn take_child(&mut self) -> Box<dyn AudioSource + Send + Sync> {
         self.child.take().unwrap()
     }
 }

--- a/plugin-flac/src/lib.rs
+++ b/plugin-flac/src/lib.rs
@@ -109,7 +109,7 @@ impl<R: Read> AudioSource for FlacAudioSource<R> {
         false
     }
 
-    fn take_child(&mut self) -> Box<dyn AudioSource + Send> {
+    fn take_child(&mut self) -> Box<dyn AudioSource + Send + Sync> {
         panic!("flac audio source has no child")
     }
 }
@@ -120,9 +120,9 @@ struct FlacAudioSourceResolver {
 
 impl FlacAudioSourceResolver {
     fn resolve_reader<R>(&self, reader: R)
-        -> Result<Box<dyn AudioSource + Send>, String>
+        -> Result<Box<dyn AudioSource + Send + Sync>, String>
     where
-        R: Read + Send + 'static
+        R: Read + Send + Sync + 'static
     {
         let reader = FlacReader::new(reader)
             .map_err(|e| format!("{}", e))?;
@@ -160,7 +160,7 @@ impl AudioSourceResolver for FlacAudioSourceResolver {
     }
 
     fn resolve(&self, descriptor: &str, guild_config: PluginGuildConfig)
-            -> Result<Box<dyn AudioSource + Send>, String> {
+            -> Result<Box<dyn AudioSource + Send + Sync>, String> {
         let file = self.file_manager.open_file_buf(descriptor, &guild_config)?;
 
         match file {

--- a/plugin-folder-list/src/lib.rs
+++ b/plugin-folder-list/src/lib.rs
@@ -75,7 +75,7 @@ impl AudioSourceListResolver for FolderListResolver {
     }
 
     fn resolve(&self, descriptor: &str, guild_config: PluginGuildConfig)
-            -> Result<Box<dyn AudioSourceList + Send>, String> {
+            -> Result<Box<dyn AudioSourceList + Send + Sync>, String> {
         let path = self.path(descriptor, &guild_config);
         let read_dir = fs::read_dir(&path).map_err(|e| format!("{}", e))?;
 

--- a/plugin-json-list/src/lib.rs
+++ b/plugin-json-list/src/lib.rs
@@ -30,7 +30,7 @@ struct JsonAudioSourceListResolver {
 
 impl JsonAudioSourceListResolver {
     fn resolve_reader<R>(&self, reader: R)
-        -> Result<Box<dyn AudioSourceList + Send>, String>
+        -> Result<Box<dyn AudioSourceList + Send + Sync>, String>
     where
         R: Read + Send + 'static
     {
@@ -72,7 +72,7 @@ impl AudioSourceListResolver for JsonAudioSourceListResolver {
     }
 
     fn resolve(&self, descriptor: &str, guild_config: PluginGuildConfig)
-            -> Result<Box<dyn AudioSourceList + Send>, String> {
+            -> Result<Box<dyn AudioSourceList + Send + Sync>, String> {
         let file = self.file_manager.open_file_buf(descriptor, &guild_config)?;
 
         match file {

--- a/plugin-loop/src/lib.rs
+++ b/plugin-loop/src/lib.rs
@@ -13,7 +13,7 @@ use std::collections::HashMap;
 use std::io;
 
 struct LoopAudioSourceList {
-    child: Box<dyn AudioSourceList + Send>,
+    child: Box<dyn AudioSourceList + Send + Sync>,
     buf: Vec<String>,
     idx: usize
 }
@@ -54,9 +54,9 @@ impl AdapterResolver for LoopAdapterResolver {
     }
 
     fn resolve(&self, _key_values: &HashMap<String, String>,
-            child: Box<dyn AudioSourceList + Send>,
+            child: Box<dyn AudioSourceList + Send + Sync>,
             _guild_config: PluginGuildConfig)
-            -> Result<Box<dyn AudioSourceList + Send>, String> {
+            -> Result<Box<dyn AudioSourceList + Send + Sync>, String> {
         Ok(Box::new(LoopAudioSourceList {
             child,
             buf: Vec::new(),

--- a/plugin-mp3/src/lib.rs
+++ b/plugin-mp3/src/lib.rs
@@ -94,7 +94,7 @@ impl<R: Read> AudioSource for Mp3AudioSource<R> {
         false
     }
 
-    fn take_child(&mut self) -> Box<dyn AudioSource + Send> {
+    fn take_child(&mut self) -> Box<dyn AudioSource + Send + Sync> {
         panic!("mp3 audio source has no child")
     }
 }
@@ -103,9 +103,9 @@ struct Mp3AudioSourceResolver {
     file_manager: FileManager
 }
 
-fn resolve_reader<R>(reader: R) -> Result<Box<dyn AudioSource + Send>, String>
+fn resolve_reader<R>(reader: R) -> Result<Box<dyn AudioSource + Send + Sync>, String>
 where
-    R: Read + Send + 'static
+    R: Read + Send + Sync + 'static
 {
     let decoder = Decoder::new(reader);
     let mut frames = FrameIterator {
@@ -149,7 +149,7 @@ impl AudioSourceResolver for Mp3AudioSourceResolver {
     }
 
     fn resolve(&self, descriptor: &str, guild_config: PluginGuildConfig)
-            -> Result<Box<dyn AudioSource + Send>, String> {
+            -> Result<Box<dyn AudioSource + Send + Sync>, String> {
         let file = self.file_manager.open_file_buf(descriptor, &guild_config)?;
     
         match file {

--- a/plugin-mp4/src/lib.rs
+++ b/plugin-mp4/src/lib.rs
@@ -206,7 +206,7 @@ impl<D: Decoder> AudioSource for Mp4AudioSource<D> {
         false
     }
 
-    fn take_child(&mut self) -> Box<dyn AudioSource + Send> {
+    fn take_child(&mut self) -> Box<dyn AudioSource + Send + Sync> {
         panic!("mp4 audio source has no child")
     }
 }
@@ -289,7 +289,7 @@ fn select_channels(channels: Channels) -> (usize, usize) {
 }
 
 fn construct_source<D>(reader: IsoMp4Reader, track: &Track)
-    -> Result<Box<dyn AudioSource + Send>, String>
+    -> Result<Box<dyn AudioSource + Send + Sync>, String>
 where
     D: Decoder + 'static
 {
@@ -319,7 +319,7 @@ where
     }, sampling_rate)))
 }
 
-fn resolve_reader<R>(reader: R) -> Result<Box<dyn AudioSource + Send>, String>
+fn resolve_reader<R>(reader: R) -> Result<Box<dyn AudioSource + Send + Sync>, String>
 where
     R: Read + Send + Sync + 'static
 {
@@ -393,7 +393,7 @@ impl AudioSourceResolver for Mp4AudioSourceResolver {
     }
 
     fn resolve(&self, descriptor: &str, guild_config: PluginGuildConfig)
-            -> Result<Box<dyn AudioSource + Send>, String> {
+            -> Result<Box<dyn AudioSource + Send + Sync>, String> {
         let file = self.file_manager.open_file_buf(descriptor, &guild_config)?;
 
         match file {

--- a/plugin-ogg/src/lib.rs
+++ b/plugin-ogg/src/lib.rs
@@ -85,7 +85,7 @@ impl<R: Read + Seek> AudioSource for OggAudioSource<R> {
         false
     }
 
-    fn take_child(&mut self) -> Box<dyn AudioSource + Send> {
+    fn take_child(&mut self) -> Box<dyn AudioSource + Send + Sync> {
         panic!("ogg audio source has no child")
     }
 }
@@ -96,9 +96,9 @@ struct OggAudioSourceResolver {
 
 impl OggAudioSourceResolver {
     fn resolve_reader<R>(&self, reader: R)
-        -> Result<Box<dyn AudioSource + Send>, String>
+        -> Result<Box<dyn AudioSource + Send + Sync>, String>
     where
-        R: Read + Seek + Send + 'static
+        R: Read + Seek + Send + Sync + 'static
     {
         let ogg_reader = OggStreamReader::new(reader)
             .map_err(|e| format!("{}", e))?;
@@ -138,7 +138,7 @@ impl AudioSourceResolver for OggAudioSourceResolver {
     }
 
     fn resolve(&self, descriptor: &str, guild_config: PluginGuildConfig)
-            -> Result<Box<dyn AudioSource + Send>, String> {
+            -> Result<Box<dyn AudioSource + Send + Sync>, String> {
         let file = self.file_manager.open_file_buf(descriptor, &guild_config)?;
     
         match file {

--- a/plugin-shuffle/src/lib.rs
+++ b/plugin-shuffle/src/lib.rs
@@ -23,7 +23,7 @@ fn shuffle<T, R: Rng>(slice: &mut [T], rng: &mut R) {
 }
 
 struct ShuffleAudioSourceList<R> {
-    child: Box<dyn AudioSourceList + Send>,
+    child: Box<dyn AudioSourceList + Send + Sync>,
     next: Option<String>,
     buf: Vec<String>,
     rng: R
@@ -77,9 +77,9 @@ impl AdapterResolver for ShuffleAdapterResolver {
     }
 
     fn resolve(&self, _key_values: &HashMap<String, String>,
-            child: Box<dyn AudioSourceList + Send>,
+            child: Box<dyn AudioSourceList + Send + Sync>,
             _guild_config: PluginGuildConfig)
-            -> Result<Box<dyn AudioSourceList + Send>, String> {
+            -> Result<Box<dyn AudioSourceList + Send + Sync>, String> {
         Ok(Box::new(ShuffleAudioSourceList {
             child,
             next: None,

--- a/plugin-volume/src/lib.rs
+++ b/plugin-volume/src/lib.rs
@@ -14,7 +14,7 @@ use rambot_api::{
 use std::{io, collections::HashMap};
 
 struct VolumeEffect {
-    child: Option<Box<dyn AudioSource + Send>>,
+    child: Option<Box<dyn AudioSource + Send + Sync>>,
     volume: f32
 }
 
@@ -33,7 +33,7 @@ impl AudioSource for VolumeEffect {
         true
     }
 
-    fn take_child(&mut self) -> Box<dyn AudioSource + Send> {
+    fn take_child(&mut self) -> Box<dyn AudioSource + Send + Sync> {
         self.child.take().unwrap()
     }
 }
@@ -69,9 +69,9 @@ impl EffectResolver for VolumeEffectResolver {
     }
 
     fn resolve(&self, key_values: &HashMap<String, String>,
-            child: Box<dyn AudioSource + Send>,
+            child: Box<dyn AudioSource + Send + Sync>,
             _guild_config: PluginGuildConfig)
-            -> Result<Box<dyn AudioSource + Send>, ResolveEffectError> {
+            -> Result<Box<dyn AudioSource + Send + Sync>, ResolveEffectError> {
         let volume = match get_volume(key_values) {
             Ok(v) => v,
             Err(msg) => return Err(ResolveEffectError::new(msg, child))

--- a/plugin-wave/src/lib.rs
+++ b/plugin-wave/src/lib.rs
@@ -116,7 +116,7 @@ impl<R: Read> AudioSource for IntWaveAudioSource<R> {
         false
     }
 
-    fn take_child(&mut self) -> Box<dyn AudioSource + Send> {
+    fn take_child(&mut self) -> Box<dyn AudioSource + Send + Sync> {
         panic!("wave audio source has no child")
     }
 }
@@ -149,7 +149,7 @@ impl<R: Read> AudioSource for FloatWaveAudioSource<R> {
         false
     }
 
-    fn take_child(&mut self) -> Box<dyn AudioSource + Send> {
+    fn take_child(&mut self) -> Box<dyn AudioSource + Send + Sync> {
         panic!("wave audio source has no child")
     }
 }
@@ -160,9 +160,9 @@ struct WaveAudioSourceResolver {
 
 impl WaveAudioSourceResolver {
     fn resolve_reader<R>(&self, reader: R)
-        -> Result<Box<dyn AudioSource + Send>, String>
+        -> Result<Box<dyn AudioSource + Send + Sync>, String>
     where
-        R: Read + Send + 'static
+        R: Read + Send + Sync + 'static
     {
         let wav_reader = WavReader::new(reader).map_err(|e| format!("{}", e))?;
         let spec = wav_reader.spec();
@@ -216,7 +216,7 @@ impl AudioSourceResolver for WaveAudioSourceResolver {
     }
 
     fn resolve(&self, descriptor: &str, guild_config: PluginGuildConfig)
-            -> Result<Box<dyn AudioSource + Send>, String> {
+            -> Result<Box<dyn AudioSource + Send + Sync>, String> {
         let file = self.file_manager.open_file_buf(descriptor, &guild_config)?;
 
         match file {

--- a/rambot-api/src/audio.rs
+++ b/rambot-api/src/audio.rs
@@ -201,10 +201,10 @@ pub trait AudioSource {
     /// Unless this method is called outside the framework, it is guaranteed
     /// that the audio source is dropped immediately afterwards. It is
     /// therefore not necessary to keep it in a usable state.
-    fn take_child(&mut self) -> Box<dyn AudioSource + Send>;
+    fn take_child(&mut self) -> Box<dyn AudioSource + Send + Sync>;
 }
 
-impl AudioSource for Box<dyn AudioSource + Send> {
+impl AudioSource for Box<dyn AudioSource + Send + Sync> {
     fn read(&mut self, buf: &mut [Sample]) -> Result<usize, io::Error> {
         self.as_mut().read(buf)
     }
@@ -213,7 +213,7 @@ impl AudioSource for Box<dyn AudioSource + Send> {
         self.as_ref().has_child()
     }
 
-    fn take_child(&mut self) -> Box<dyn AudioSource + Send> {
+    fn take_child(&mut self) -> Box<dyn AudioSource + Send + Sync> {
         self.as_mut().take_child()
     }
 }

--- a/rambot-test-util/src/lib.rs
+++ b/rambot-test-util/src/lib.rs
@@ -178,7 +178,7 @@ impl<D: Distribution<usize>, R: Rng> AudioSource for MockAudioSource<D, R> {
         false
     }
 
-    fn take_child(&mut self) -> Box<dyn AudioSource + Send> {
+    fn take_child(&mut self) -> Box<dyn AudioSource + Send + Sync> {
         panic!("mock audio source asked for child")
     }
 }

--- a/rambot/src/command/adapter.rs
+++ b/rambot/src/command/adapter.rs
@@ -1,8 +1,8 @@
 use crate::audio::Layer;
 use crate::command::{
+    configure_layer,
     help_modifiers,
-    list_layer_key_value_descriptors,
-    with_mixer_and_layer
+    list_layer_key_value_descriptors
 };
 use crate::key_value::KeyValueDescriptor;
 use crate::plugin::PluginManager;
@@ -37,7 +37,8 @@ pub fn get_adapter_commands() -> &'static CommandGroup {
 )]
 async fn add(ctx: &Context, msg: &Message, layer: String,
         adapter: KeyValueDescriptor) -> CommandResult<Option<String>> {
-    let success = with_mixer_and_layer(ctx, msg, &layer,
+    let guild_id = msg.guild_id.unwrap();
+    let success = configure_layer(ctx, guild_id, &layer,
         |mut mixer| mixer.add_adapter(&layer, adapter)).await.is_some();
 
     if success {
@@ -57,7 +58,8 @@ async fn add(ctx: &Context, msg: &Message, layer: String,
 )]
 async fn clear(ctx: &Context, msg: &Message, layer: String,
         name: Option<String>) -> CommandResult<Option<String>> {
-    let removed = with_mixer_and_layer(ctx, msg, &layer, |mut mixer|
+    let guild_id = msg.guild_id.unwrap();
+    let removed = configure_layer(ctx, guild_id, &layer, |mut mixer|
         if let Some(name) = &name {
             mixer.retain_adapters(&layer,
                 |descriptor| &descriptor.name != name)

--- a/rambot/src/command/effect.rs
+++ b/rambot/src/command/effect.rs
@@ -1,8 +1,8 @@
 use crate::audio::Layer;
 use crate::command::{
+    configure_layer,
     help_modifiers,
-    list_layer_key_value_descriptors,
-    with_mixer_and_layer
+    list_layer_key_value_descriptors
 };
 use crate::key_value::KeyValueDescriptor;
 use crate::plugin::PluginManager;
@@ -37,7 +37,8 @@ pub fn get_effect_commands() -> &'static CommandGroup {
 )]
 async fn add(ctx: &Context, msg: &Message, layer: String,
         effect: KeyValueDescriptor) -> CommandResult<Option<String>> {
-    let res = with_mixer_and_layer(ctx, msg, &layer,
+    let guild_id = msg.guild_id.unwrap();
+    let res = configure_layer(ctx, guild_id, &layer,
         |mut mixer| mixer.add_effect(&layer, effect)).await;
 
     match res {
@@ -56,7 +57,8 @@ async fn add(ctx: &Context, msg: &Message, layer: String,
 )]
 async fn clear(ctx: &Context, msg: &Message, layer: String,
         name: Option<String>) -> CommandResult<Option<String>> {
-    let res = with_mixer_and_layer(ctx, msg, &layer, |mut mixer|
+    let guild_id = msg.guild_id.unwrap();
+    let res = configure_layer(ctx, guild_id, &layer, |mut mixer|
         if let Some(name) = &name {
             mixer.retain_effects(&layer,
                 |descriptor| &descriptor.name != name)

--- a/rambot/src/command/layer.rs
+++ b/rambot/src/command/layer.rs
@@ -1,4 +1,4 @@
-use crate::command::with_mixer;
+use crate::command::{configure_guild_state, with_guild_state};
 
 use rambot_proc_macro::rambot_command;
 
@@ -25,8 +25,9 @@ pub fn get_layer_commands() -> &'static CommandGroup {
 )]
 async fn add(ctx: &Context, msg: &Message, layer: String)
         -> CommandResult<Option<String>> {
-    let added = with_mixer(ctx, msg, move |mut mixer|
-        mixer.add_layer(layer)).await;
+    let guild_id = msg.guild_id.unwrap();
+    let added = configure_guild_state(ctx, guild_id, move |gs|
+        gs.mixer_mut().add_layer(layer)).await;
 
     if added {
         Ok(None)
@@ -44,8 +45,9 @@ async fn add(ctx: &Context, msg: &Message, layer: String)
 )]
 async fn remove(ctx: &Context, msg: &Message, layer: String)
         -> CommandResult<Option<String>> {
-    let removed = with_mixer(ctx, msg, move |mut mixer|
-        mixer.remove_layer(&layer)).await;
+    let guild_id = msg.guild_id.unwrap();
+    let removed = configure_guild_state(ctx, guild_id, move |gs|
+        gs.mixer_mut().remove_layer(&layer)).await;
 
     if removed {
         Ok(None)
@@ -61,9 +63,10 @@ async fn remove(ctx: &Context, msg: &Message, layer: String)
     usage = ""
 )]
 async fn list(ctx: &Context, msg: &Message) -> CommandResult {
-    let layers = with_mixer(ctx, msg, |mixer| {
-        mixer.layers().iter().map(|l| l.name().to_owned()).collect::<Vec<_>>()
-    }).await;
+    let guild_id = msg.guild_id.unwrap();
+    let layers = with_guild_state(ctx, guild_id, |gs| {
+        gs.mixer().layers().iter().map(|l| l.name().to_owned()).collect::<Vec<_>>()
+    }).await.unwrap_or_else(Vec::new);
 
     let response = if layers.is_empty() {
         "No layers registered in this guild.".to_owned()

--- a/rambot/src/command/layer.rs
+++ b/rambot/src/command/layer.rs
@@ -66,7 +66,7 @@ async fn list(ctx: &Context, msg: &Message) -> CommandResult {
     let guild_id = msg.guild_id.unwrap();
     let layers = with_guild_state(ctx, guild_id, |gs| {
         gs.mixer().layers().iter().map(|l| l.name().to_owned()).collect::<Vec<_>>()
-    }).await.unwrap_or_else(Vec::new);
+    }).await.unwrap_or_default();
 
     let response = if layers.is_empty() {
         "No layers registered in this guild.".to_owned()

--- a/rambot/src/plugin.rs
+++ b/rambot/src/plugin.rs
@@ -103,7 +103,7 @@ pub enum AudioDescriptorList {
 
     /// An [AudioSourceList] providing audio descriptors, which is wrapped in
     /// this variant.
-    List(Box<dyn AudioSourceList + Send>)
+    List(Box<dyn AudioSourceList + Send + Sync>)
 }
 
 trait AudioResolver {
@@ -117,7 +117,7 @@ trait AudioResolver {
 }
 
 impl AudioResolver for Box<dyn AudioSourceResolver> {
-    type Value = Box<dyn AudioSource + Send>;
+    type Value = Box<dyn AudioSource + Send + Sync>;
 
     fn can_resolve(&self, descriptor: &str,
             plugin_guild_config: PluginGuildConfig) -> bool {
@@ -131,7 +131,7 @@ impl AudioResolver for Box<dyn AudioSourceResolver> {
 }
 
 impl AudioResolver for Box<dyn AudioSourceListResolver> {
-    type Value = Box<dyn AudioSourceList + Send>;
+    type Value = Box<dyn AudioSourceList + Send + Sync>;
 
     fn can_resolve(&self, descriptor: &str,
             plugin_guild_config: PluginGuildConfig) -> bool {
@@ -362,7 +362,7 @@ impl PluginManager {
     /// Any [ResolveError] according to their respective documentation.
     pub fn resolve_audio_source(&self, descriptor: &str,
             plugin_guild_config: &PluginGuildConfig)
-            -> Result<Box<dyn AudioSource + Send>, ResolveError> {
+            -> Result<Box<dyn AudioSource + Send + Sync>, ResolveError> {
         resolve_audio(descriptor, plugin_guild_config,
             &self.audio_source_resolvers)
     }
@@ -387,7 +387,7 @@ impl PluginManager {
     /// Any [ResolveError] according to their respective documentation.
     pub fn resolve_audio_source_list(&self, descriptor: &str,
             plugin_guild_config: &PluginGuildConfig)
-            -> Result<Box<dyn AudioSourceList + Send>, ResolveError> {
+            -> Result<Box<dyn AudioSourceList + Send + Sync>, ResolveError> {
         resolve_audio(descriptor, plugin_guild_config,
             &self.audio_source_list_resolvers)
     }
@@ -466,10 +466,10 @@ impl PluginManager {
     /// Any [ResolveError] according to their respective documentation.
     pub fn resolve_effect(&self, name: &str,
             key_values: &HashMap<String, String>,
-            child: Box<dyn AudioSource + Send>,
+            child: Box<dyn AudioSource + Send + Sync>,
             plugin_guild_config: &PluginGuildConfig)
-            -> Result<Box<dyn AudioSource + Send>,
-                (ResolveError, Box<dyn AudioSource + Send>)> {
+            -> Result<Box<dyn AudioSource + Send + Sync>,
+                (ResolveError, Box<dyn AudioSource + Send + Sync>)> {
         if let Some(resolver) = self.effect_resolvers.get(name) {
             resolver.resolve(key_values, child, plugin_guild_config.clone())
                 .map_err(|e| {
@@ -534,9 +534,9 @@ impl PluginManager {
     /// Any [ResolveError] according to their respective documentation.
     pub fn resolve_adapter(&self, name: &str,
             key_values: &HashMap<String, String>,
-            child: Box<dyn AudioSourceList + Send>,
+            child: Box<dyn AudioSourceList + Send + Sync>,
             plugin_guild_config: &PluginGuildConfig)
-            -> Result<Box<dyn AudioSourceList + Send>, ResolveError> {
+            -> Result<Box<dyn AudioSourceList + Send + Sync>, ResolveError> {
         if let Some(resolver) = self.adapter_resolvers.get(name) {
             resolver.resolve(key_values, child, plugin_guild_config.clone())
                 .map_err(ResolveError::PluginResolveError)

--- a/rambot/src/state.rs
+++ b/rambot/src/state.rs
@@ -229,7 +229,8 @@ impl Display for StateError {
 /// corresponding file after modification has finished.
 pub struct GuildStateGuard<'a> {
     guild_state: &'a mut GuildState,
-    path: PathBuf
+    path: PathBuf,
+    id: GuildId
 }
 
 impl<'a> Deref for GuildStateGuard<'a> {
@@ -266,6 +267,8 @@ impl<'a> Drop for GuildStateGuard<'a> {
         if let Err(e) = serde_json::to_writer(file, &self.guild_state) {
             log::warn!("Could not save changed state: {}", e);
         }
+
+        log::debug!("Saved state for guild {}.", self.id);
     }
 }
 
@@ -364,7 +367,8 @@ impl State {
 
         GuildStateGuard {
             path: file_path,
-            guild_state
+            guild_state,
+            id
         }
     }
 

--- a/rambot/src/state.rs
+++ b/rambot/src/state.rs
@@ -17,11 +17,11 @@ use std::io;
 use std::num::ParseIntError;
 use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 /// The bot's state for one specific guild.
 pub struct GuildState {
-    mixer: Arc<Mutex<Mixer>>,
+    mixer: Arc<RwLock<Mixer>>,
     board_manager: BoardManager,
     root_directory: Option<String>
 }
@@ -31,7 +31,7 @@ impl GuildState {
         log::info!("New guild state created.");
 
         GuildState {
-            mixer: Arc::new(Mutex::new(Mixer::new(plugin_manager))),
+            mixer: Arc::new(RwLock::new(Mixer::new(plugin_manager))),
             board_manager: BoardManager::new(),
             root_directory: None
         }
@@ -60,15 +60,28 @@ impl GuildState {
         }
         
         GuildState {
-            mixer: Arc::new(Mutex::new(mixer)),
+            mixer: Arc::new(RwLock::new(mixer)),
             board_manager,
             root_directory: serde.directory
         }
     }
 
-    /// Gets an [Arc] to a [Mutex]ed audio [Mixer] for audio playback in this
-    /// guild. This also manages the layers.
-    pub fn mixer(&self) -> Arc<Mutex<Mixer>> {
+    /// Read-locks the [Mixer] for this guild and returns an appropriate guard.
+    pub fn mixer(&self) -> RwLockReadGuard<Mixer> {
+        self.mixer.read().unwrap()
+    }
+
+    /// Write-locks the [Mixer] for this guild and returns an appropriate
+    /// guard. Note that while this method only requires an immutable
+    /// reference, modifying any configuration of the mixer should only be done
+    /// while the guild state is behind a [GuildStateGuard]. This ensures that
+    /// any changes in the configuration are propagated to the associated file
+    /// on the hard drive.
+    pub fn mixer_mut(&self) -> RwLockWriteGuard<Mixer> {
+        self.mixer.write().unwrap()
+    }
+
+    pub fn mixer_arc(&self) -> Arc<RwLock<Mixer>> {
         Arc::clone(&self.mixer)
     }
 
@@ -104,7 +117,7 @@ impl GuildState {
     fn serde(&self) -> SerdeGuildState {
         let mut layers = Vec::new();
 
-        for layer in self.mixer.lock().unwrap().layers() {
+        for layer in self.mixer.read().unwrap().layers() {
             layers.push(SerdeLayer {
                 name: layer.name().to_owned(),
                 effects: layer.effects().to_vec(),
@@ -333,16 +346,15 @@ impl State {
 
     /// Gets an immutable reference to the [GuildState] with the given ID. This
     /// is intended to be used whenever any potential state changes do not need
-    /// to be saved.
-    pub fn guild_state(&mut self, id: GuildId,
-            plugin_manager: Arc<PluginManager>) -> &GuildState {
-        self.guild_states.entry(id)
-            .or_insert_with(|| GuildState::new(plugin_manager))
+    /// to be saved. If no guild state for the given ID exists yet, `None` is
+    /// returned.
+    pub fn guild_state(&self, id: GuildId) -> Option<&GuildState> {
+        self.guild_states.get(&id)
     }
 
-    /// Gets a [GuildStateGuard] to the [GuildState] with the given ID. This is
-    /// intended to be used whenever any potential state changes need to be
-    /// saved.
+    /// Gets a [GuildStateGuard] to the [GuildState] with the given ID. Any
+    /// changes in the configuration will be comitted to the hard drive once
+    /// the guard goes out of scope.
     pub fn guild_state_mut(&mut self, id: GuildId,
             plugin_manager: Arc<PluginManager>) -> GuildStateGuard<'_> {
         let path = Path::new(&self.directory);
@@ -354,6 +366,15 @@ impl State {
             path: file_path,
             guild_state
         }
+    }
+
+    /// Gets a raw mutable reference to the [GuildState] with the given ID.
+    /// Only use this if you do not intend any changes to be stored on the hard
+    /// drive! If you alter the configuration in any way, use
+    /// [State::guild_state_mut] instead.
+    pub fn guild_state_mut_unguarded(&mut self, id: GuildId)
+            -> Option<&mut GuildState> {
+        self.guild_states.get_mut(&id)
     }
 
     /// Gets the number of guilds for which a state is registered.


### PR DESCRIPTION
Instead of grabbing a GuildStateGuard every time anything is done with a guild state, a finer structure is now upheld that ensures only real configuration changes are commited to the hard drive. This resolves #83