### PR TITLE
Removed redundant allow

### DIFF
--- a/plugin-flac/src/lib.rs
+++ b/plugin-flac/src/lib.rs
@@ -1,6 +1,3 @@
-// TODO occasionally check for ouroboros update that mitigates this issue
-#![allow(clippy::drop_non_drop)]
-
 use claxon::FlacReader;
 use claxon::frame::{Block, FrameReader};
 use claxon::input::BufferedReader;


### PR DESCRIPTION
Ouroboros fixed a clippy warning, so that now no longer needs to be ignored.