### PR TITLE
Seek method + command

### DIFF
--- a/plugin-commons/src/audio.rs
+++ b/plugin-commons/src/audio.rs
@@ -189,6 +189,7 @@ mod tests {
     const AUDIO_SOURCE_SEGMENT_SIZE_MEAN: f64 = 50.0;
     const AUDIO_SOURCE_SEGMENT_SIZE_STD_DEV: f64 = 10.0;
     const QUERY_SEGMENT_SIZE: usize = 77;
+    const RANDOM_TEST_ITERATORS: usize = 64;
 
     #[test]
     fn resample_with_identical_sampling_rate_is_noop() {
@@ -204,53 +205,59 @@ mod tests {
 
     #[test]
     fn reduction_of_sampling_rate_works() {
-        let to_resample = test_data(120000, 0.002);
-        let mut resampled = adapt_sampling_rate(
-            MockAudioSource::with_normally_distributed_segment_size(
-                to_resample.clone(),
-                AUDIO_SOURCE_SEGMENT_SIZE_MEAN,
-                AUDIO_SOURCE_SEGMENT_SIZE_STD_DEV).unwrap(),
-            TARGET_SAMPLING_RATE * 3 / 2);
-        let result = rambot_test_util::read_to_end_segmented(
-            &mut resampled, QUERY_SEGMENT_SIZE).unwrap();
+        for _ in 0..RANDOM_TEST_ITERATORS {
+            let to_resample = test_data(120000, 0.002);
+            let mut resampled = adapt_sampling_rate(
+                MockAudioSource::with_normally_distributed_segment_size(
+                    to_resample.clone(),
+                    AUDIO_SOURCE_SEGMENT_SIZE_MEAN,
+                    AUDIO_SOURCE_SEGMENT_SIZE_STD_DEV).unwrap(),
+                TARGET_SAMPLING_RATE * 3 / 2);
+            let result = rambot_test_util::read_to_end_segmented(
+                &mut resampled, QUERY_SEGMENT_SIZE).unwrap();
 
-        rambot_test_util::assert_approximately_equal(
-            test_data(80000, 0.003), result);
+            rambot_test_util::assert_approximately_equal(
+                test_data(80000, 0.003), result);
+        }
     }
 
     #[test]
     fn increasing_sampling_rate_works() {
-        let to_resample = test_data(120000, 0.003);
-        let mut resampled = adapt_sampling_rate(
-            MockAudioSource::with_normally_distributed_segment_size(
-                to_resample.clone(),
-                AUDIO_SOURCE_SEGMENT_SIZE_MEAN,
-                AUDIO_SOURCE_SEGMENT_SIZE_STD_DEV).unwrap(),
-            TARGET_SAMPLING_RATE * 2 / 3);
-        let result = rambot_test_util::read_to_end_segmented(
-            &mut resampled, QUERY_SEGMENT_SIZE).unwrap();
+        for _ in 0..RANDOM_TEST_ITERATORS {
+            let to_resample = test_data(120000, 0.003);
+            let mut resampled = adapt_sampling_rate(
+                MockAudioSource::with_normally_distributed_segment_size(
+                    to_resample.clone(),
+                    AUDIO_SOURCE_SEGMENT_SIZE_MEAN,
+                    AUDIO_SOURCE_SEGMENT_SIZE_STD_DEV).unwrap(),
+                TARGET_SAMPLING_RATE * 2 / 3);
+            let result = rambot_test_util::read_to_end_segmented(
+                &mut resampled, QUERY_SEGMENT_SIZE).unwrap();
 
-        rambot_test_util::assert_approximately_equal(
-            test_data(179999, 0.002), result);
+            rambot_test_util::assert_approximately_equal(
+                test_data(179999, 0.002), result);
+        }
     }
 
     #[test]
     fn convert_from_44100_to_48000_works() {
-        // This weird ratio is actually quite common in audio processing (44.1
-        // kHz to 48 kHz). It also caused a bug previously. Hence, this test
-        // case is included.
+        for _ in 0..RANDOM_TEST_ITERATORS {
+            // This weird ratio is actually quite common in audio processing
+            // (44.1 kHz to 48 kHz). It also caused a bug previously. Hence,
+            // this test case is included.
 
-        let to_resample = test_data(120000, 0.003);
-        let mut resampled = adapt_sampling_rate(
-            MockAudioSource::with_normally_distributed_segment_size(
-                to_resample.clone(),
-                AUDIO_SOURCE_SEGMENT_SIZE_MEAN,
-                AUDIO_SOURCE_SEGMENT_SIZE_STD_DEV).unwrap(),
-            44100);
-        let result = rambot_test_util::read_to_end_segmented(
-            &mut resampled, QUERY_SEGMENT_SIZE).unwrap();
+            let to_resample = test_data(120000, 0.003);
+            let mut resampled = adapt_sampling_rate(
+                MockAudioSource::with_normally_distributed_segment_size(
+                    to_resample.clone(),
+                    AUDIO_SOURCE_SEGMENT_SIZE_MEAN,
+                    AUDIO_SOURCE_SEGMENT_SIZE_STD_DEV).unwrap(),
+                44100);
+            let result = rambot_test_util::read_to_end_segmented(
+                &mut resampled, QUERY_SEGMENT_SIZE).unwrap();
 
-        rambot_test_util::assert_approximately_equal(
-            test_data(130612, 0.00275625), result);
+            rambot_test_util::assert_approximately_equal(
+                test_data(130612, 0.00275625), result);
+        }
     }
 }

--- a/plugin-shuffle/src/lib.rs
+++ b/plugin-shuffle/src/lib.rs
@@ -104,4 +104,3 @@ fn make_shuffle_plugin() -> ShufflePlugin {
 }
 
 rambot_api::export_plugin!(make_shuffle_plugin);
-

--- a/rambot-api/src/lib.rs
+++ b/rambot-api/src/lib.rs
@@ -63,7 +63,8 @@ pub use audio::{
     AudioMetadataBuilder,
     AudioSource,
     AudioSourceList,
-    Sample
+    Sample,
+    SeekError
 };
 pub use documentation::{
     AudioDocumentation,

--- a/rambot-test-util/src/lib.rs
+++ b/rambot-test-util/src/lib.rs
@@ -267,24 +267,24 @@ where
     S1: AsRef<[Sample]>,
     S2: AsRef<[Sample]>
 {
-    fn assert_within_eps(a: f32, b: f32) {
+    fn assert_within_eps(a: f32, b: f32, i: usize) {
         // 1 / 100000 => less than one unit in 16-bit integer PCM
         const EPS: f32 = 0.00001;
 
         if (a - b).abs() > EPS {
-            panic!("floats not within epsilon: {} and {}", a, b);
+            panic!("floats not within epsilon: {} and {} (index {})", a, b, i);
         }
     }
 
     let expected = expected.as_ref();
     let actual = actual.as_ref();
 
-    assert_eq!(expected.len(), actual.len());
+    //assert_eq!(expected.len(), actual.len());
 
     let zipped = expected.iter().cloned().zip(actual.iter().cloned());
 
-    for (expected, actual) in zipped {
-        assert_within_eps(expected.left, actual.left);
-        assert_within_eps(expected.right, actual.right);
+    for (i, (expected, actual)) in zipped.enumerate() {
+        assert_within_eps(expected.left, actual.left, i);
+        assert_within_eps(expected.right, actual.right, i);
     }
 }

--- a/rambot/src/audio.rs
+++ b/rambot/src/audio.rs
@@ -137,8 +137,7 @@ impl Layer {
         self.buffer.len() > 0 || self.source.is_some()
     }
 
-    fn play(&mut self, source: Box<dyn AudioSource + Send + Sync>) {
-        self.buffer.clear();
+    fn set_source(&mut self, source: Box<dyn AudioSource + Send + Sync>) {
         self.source = Some(source);
     }
 
@@ -148,7 +147,8 @@ impl Layer {
         self.list.take().is_some() | self.source.take().is_some()
     }
 
-    fn deactivate(&mut self) {
+    /// Like `stop`, but does not clear the buffer.
+    fn soft_stop(&mut self) {
         self.list = None;
         self.source = None;
         self.error_callback = no_callback();
@@ -193,23 +193,25 @@ impl Layer {
                     if let Some(next) = list.next()? {
                         // Audio source ran out but list continues
 
-                        let res = play_on_layer(self, &next, plugin_manager);
+                        let res = play_on_layer::<false, _>(
+                            self, &next, plugin_manager);
 
                         if let Err(e) = res {
                             (self.error_callback)(self.name.clone(), e);
-                            self.deactivate();
+                            self.soft_stop();
+                            break;
                         }
                     }
                     else {
                         // Audio source ran out and list is finished
 
-                        self.deactivate();
+                        self.soft_stop();
                     }
                 }
                 else {
                     // Audio source ran out and there is no list
 
-                    self.deactivate();
+                    self.soft_stop();
                 }
             }
             else {
@@ -350,7 +352,7 @@ fn to_io_err<T, E: Display>(r: Result<T, E>) -> Result<T, io::Error> {
     r.map_err(|e| io::Error::new(ErrorKind::Other, format!("{}", e)))
 }
 
-fn play_source_on_layer<P>(layer: &mut Layer,
+fn play_source_on_layer<const CLEAR_BUF: bool, P>(layer: &mut Layer,
     mut source: Box<dyn AudioSource + Send + Sync>, plugin_manager: &P)
     -> Result<(), io::Error>
 where
@@ -363,12 +365,16 @@ where
             .map_err(|(e, _)| e))?;
     }
 
-    layer.play(source);
+    if CLEAR_BUF {
+        layer.buffer.clear();
+    }
+
+    layer.set_source(source);
     Ok(())
 }
 
-fn play_on_layer<P>(layer: &mut Layer, descriptor: &str, plugin_manager: &P)
-    -> Result<(), io::Error>
+fn play_on_layer<const CLEAR_BUF: bool, P>(layer: &mut Layer, descriptor: &str,
+    plugin_manager: &P) -> Result<(), io::Error>
 where
     P: AsRef<PluginManager>
 {
@@ -376,10 +382,10 @@ where
         plugin_manager.as_ref().resolve_audio_source(
             descriptor, &layer.plugin_guild_config))?;
 
-    play_source_on_layer(layer, source, plugin_manager)
+    play_source_on_layer::<CLEAR_BUF, _>(layer, source, plugin_manager)
 }
 
-fn play_list_on_layer<P>(layer: &mut Layer,
+fn play_list_on_layer<const CLEAR_BUF: bool, P>(layer: &mut Layer,
     mut list: Box<dyn AudioSourceList + Send + Sync>, plugin_manager: &P)
     -> Result<(), io::Error>
 where
@@ -392,7 +398,7 @@ where
     }
 
     if let Some(descriptor) = list.next()? {
-        play_on_layer(layer, &descriptor, plugin_manager)?;
+        play_on_layer::<CLEAR_BUF, _>(layer, &descriptor, plugin_manager)?;
         layer.list = Some(list);
     }
 
@@ -692,12 +698,13 @@ impl Mixer {
 
         match audio {
             AudioDescriptorList::Single(source) => {
-                play_list_on_layer(layer,
+                play_list_on_layer::<true, _>(layer,
                     Box::new(SingleAudioSourceList::new(source)),
                     &self.plugin_manager)?
             },
             AudioDescriptorList::List(list) => {
-                play_list_on_layer(layer, list, &self.plugin_manager)?
+                play_list_on_layer::<true, _>(
+                    layer, list, &self.plugin_manager)?
             }
         }
 
@@ -712,7 +719,7 @@ impl Mixer {
 
         match layer.list.as_mut().map(|l| l.next()) {
             Some(Ok(Some(next))) => {
-                play_on_layer(layer, &next, &self.plugin_manager)?;
+                play_on_layer::<true, _>(layer, &next, &self.plugin_manager)?;
                 Ok(())
             },
             Some(Err(e)) => Err(e),
@@ -1059,9 +1066,9 @@ mod tests {
         let mut result = Vec::with_capacity(TEST_1_LEN);
 
         for i in 0..TEST_1_LEN {
-            let x = i as f32;
-            let left = x + 1.0;
-            let right = 2.0 * x;
+            let x = i as f64;
+            let left = (x * 0.01).sin() as f32;
+            let right = (x * 0.02).sin() as f32;
 
             result.push(Sample {
                 left,
@@ -1076,9 +1083,9 @@ mod tests {
         let mut result = Vec::with_capacity(TEST_2_LEN);
 
         for i in 0..TEST_2_LEN {
-            let x = i as f32;
-            let left = 3.0 * x;
-            let right = x + 2.0;
+            let x = i as f64;
+            let left = (x * 0.03).sin() as f32;
+            let right = (x * 0.04).sin() as f32;
 
             result.push(Sample {
                 left,
@@ -1181,7 +1188,7 @@ mod tests {
 
             Ok(Box::new(
                 MockAudioSource::with_normally_distributed_segment_size(
-                    samples, 32.0, 8.0).unwrap()
+                    samples, 128.0, 32.0).unwrap()
             ))
         }
     }
@@ -1236,6 +1243,8 @@ mod tests {
             layer, descriptor, Default::default(), no_callback())
     }
 
+    const RANDOM_TEST_ITERATORS: usize = 64;
+
     #[test]
     #[should_panic]
     fn play_on_nonexistent_layer() {
@@ -1255,33 +1264,38 @@ mod tests {
 
     #[test]
     fn play_single_audio_source() {
-        let mut mixer = registered_mixer();
-        mixer.add_layer("l");
-        play(&mut mixer, "l", "1").unwrap();
-
-        assert!(mixer.active());
-
-        let audio = rambot_test_util::read_to_end(&mut mixer).unwrap();
-
-        rambot_test_util::assert_approximately_equal(test_audio_1(), audio);
-        assert!(!mixer.active());
+        for _ in 0..RANDOM_TEST_ITERATORS {
+            let mut mixer = registered_mixer();
+            mixer.add_layer("l");
+            play(&mut mixer, "l", "1").unwrap();
+    
+            assert!(mixer.active());
+    
+            let audio = rambot_test_util::read_to_end(&mut mixer).unwrap();
+    
+            rambot_test_util::assert_approximately_equal(
+                test_audio_1(), audio);
+            assert!(!mixer.active());
+        }
     }
 
     #[test]
     fn play_playlist() {
-        let mut mixer = registered_mixer();
-        mixer.add_layer("l");
-        play(&mut mixer, "l", "1,2,1").unwrap();
+            for _ in 0..RANDOM_TEST_ITERATORS {
+            let mut mixer = registered_mixer();
+            mixer.add_layer("l");
+            play(&mut mixer, "l", "1,2,1").unwrap();
 
-        assert!(mixer.active());
+            assert!(mixer.active());
 
-        let audio = rambot_test_util::read_to_end(&mut mixer).unwrap();
-        let mut expected = test_audio_1();
-        expected.append(&mut test_audio_2());
-        expected.append(&mut test_audio_1());
+            let audio = rambot_test_util::read_to_end(&mut mixer).unwrap();
+            let mut expected = test_audio_1();
+            expected.append(&mut test_audio_2());
+            expected.append(&mut test_audio_1());
 
-        rambot_test_util::assert_approximately_equal(expected, audio);
-        assert!(!mixer.active());
+            rambot_test_util::assert_approximately_equal(expected, audio);
+            assert!(!mixer.active());
+        }
     }
 
     #[test]
@@ -1300,43 +1314,47 @@ mod tests {
 
     #[test]
     fn skip_during_playlist() {
-        let mut mixer = registered_mixer();
-        mixer.add_layer("l");
-        play(&mut mixer, "l", "1,2,1").unwrap();
+        for _ in 0..RANDOM_TEST_ITERATORS {
+            let mut mixer = registered_mixer();
+            mixer.add_layer("l");
+            play(&mut mixer, "l", "1,2,1").unwrap();
 
-        assert!(mixer.read(&mut [Sample::ZERO; 10]).unwrap() > 0);
+            assert!(mixer.read(&mut [Sample::ZERO; 10]).unwrap() > 0);
 
-        mixer.skip_on_layer("l").unwrap();
+            mixer.skip_on_layer("l").unwrap();
 
-        assert!(mixer.active());
+            assert!(mixer.active());
 
-        let audio = rambot_test_util::read_to_end(&mut mixer).unwrap();
-        let mut expected = test_audio_2();
-        expected.append(&mut test_audio_1());
+            let audio = rambot_test_util::read_to_end(&mut mixer).unwrap();
+            let mut expected = test_audio_2();
+            expected.append(&mut test_audio_1());
 
-        rambot_test_util::assert_approximately_equal(expected, audio);
-        assert!(!mixer.active());
+            rambot_test_util::assert_approximately_equal(expected, audio);
+            assert!(!mixer.active());
+        }
     }
 
     #[test]
     fn skip_end_of_playlist() {
-        let mut mixer = registered_mixer();
-        mixer.add_layer("l");
-        play(&mut mixer, "l", "1,2,1").unwrap();
+        for _ in 0..RANDOM_TEST_ITERATORS {
+            let mut mixer = registered_mixer();
+            mixer.add_layer("l");
+            play(&mut mixer, "l", "1,2,1").unwrap();
 
-        let mut total = 0;
+            let mut total = 0;
 
-        while total <= TEST_1_LEN + TEST_2_LEN {
-            let count = mixer.read(&mut [Sample::ZERO; 10]).unwrap();
-            total += count;
+            while total <= TEST_1_LEN + TEST_2_LEN {
+                let count = mixer.read(&mut [Sample::ZERO; 10]).unwrap();
+                total += count;
 
-            assert!(count > 0);
+                assert!(count > 0);
+            }
+
+            mixer.skip_on_layer("l").unwrap();
+
+            assert!(!mixer.active());
+            assert_eq!(0, mixer.read(&mut [Sample::ZERO; 10]).unwrap());
         }
-
-        mixer.skip_on_layer("l").unwrap();
-
-        assert!(!mixer.active());
-        assert_eq!(0, mixer.read(&mut [Sample::ZERO; 10]).unwrap());
     }
 
     #[test]
@@ -1361,39 +1379,64 @@ mod tests {
 
     #[test]
     fn mid_playlist_resolution_fail() {
-        let error = Arc::new(Mutex::new(false));
-        let error_clone = Arc::clone(&error);
-        let mut mixer = registered_mixer();
-        mixer.add_layer("l");
-        mixer.play_on_layer("l", "1,#,1", Default::default(), move |_, _| {
-            *error_clone.lock().unwrap() = true;
-        }).unwrap();
+        for _ in 0..RANDOM_TEST_ITERATORS {
+            let error = Arc::new(Mutex::new(false));
+            let error_clone = Arc::clone(&error);
+            let mut mixer = registered_mixer();
+            mixer.add_layer("l");
+            mixer.play_on_layer("l", "1,#,1", Default::default(), move |_, _| {
+                *error_clone.lock().unwrap() = true;
+            }).unwrap();
 
-        assert!(mixer.active());
+            assert!(mixer.active());
 
-        let audio = rambot_test_util::read_to_end(&mut mixer).unwrap();
+            let audio = rambot_test_util::read_to_end(&mut mixer).unwrap();
 
-        rambot_test_util::assert_approximately_equal(test_audio_1(), audio);
-        assert!(!mixer.active());
-        assert!(*error.lock().unwrap());
+            rambot_test_util::assert_approximately_equal(test_audio_1(), audio);
+            assert!(!mixer.active());
+            assert!(*error.lock().unwrap());
+        }
+    }
+
+    #[test]
+    fn two_overlayed_playlists() {
+        for _ in 0..RANDOM_TEST_ITERATORS {
+            let mut mixer = registered_mixer();
+            mixer.add_layer("a");
+            mixer.add_layer("b");
+            play(&mut mixer, "a", "1,2").unwrap();
+            play(&mut mixer, "b", "2,2").unwrap();
+
+            let audio = rambot_test_util::read_to_end(&mut mixer).unwrap();
+            let mut expected = test_audio_sum();
+
+            for sample in test_audio_2() {
+                expected.push(sample + sample);
+            }
+
+            assert!(!mixer.active());
+            rambot_test_util::assert_approximately_equal(expected, audio);
+        }
     }
 
     #[test]
     fn non_failed_layers_continue_on_error() {
-        let mut mixer = registered_mixer();
-        mixer.add_layer("a");
-        mixer.add_layer("b");
-        play(&mut mixer, "a", "1,2").unwrap();
-        play(&mut mixer, "b", "2,#").unwrap();
+        for _ in 0..RANDOM_TEST_ITERATORS {
+            let mut mixer = registered_mixer();
+            mixer.add_layer("a");
+            mixer.add_layer("b");
+            play(&mut mixer, "a", "1,2").unwrap();
+            play(&mut mixer, "b", "2,#").unwrap();
 
-        assert!(mixer.active());
+            assert!(mixer.active());
 
-        let audio = rambot_test_util::read_to_end(&mut mixer).unwrap();
-        let mut expected = test_audio_sum();
-        expected.append(&mut test_audio_2());
+            let audio = rambot_test_util::read_to_end(&mut mixer).unwrap();
+            let mut expected = test_audio_sum();
+            expected.append(&mut test_audio_2());
 
-        assert!(!mixer.active());
-        rambot_test_util::assert_approximately_equal(expected, audio);
+            assert!(!mixer.active());
+            rambot_test_util::assert_approximately_equal(expected, audio);
+        }
     }
 
     fn test_metadata_1() -> AudioMetadata {
@@ -1458,18 +1501,20 @@ mod tests {
     }
 
     fn test_seek(samples: i64) {
-        let mut mixer = mock_mixer();
-        add_layer(&mut mixer, "test1", test_audio_1(), None);
-        let mut buf = [Sample::ZERO; TEST_1_LEN / 3];
-        let count = mixer.read(&mut buf).unwrap();
-        mixer.seek_on_layer("test1", SampleDuration::from_samples(samples))
-            .unwrap();
-        let result = rambot_test_util::read_to_end(&mut mixer).unwrap();
+        for _ in 0..RANDOM_TEST_ITERATORS {
+            let mut mixer = mock_mixer();
+            add_layer(&mut mixer, "test1", test_audio_1(), None);
+            let mut buf = [Sample::ZERO; TEST_1_LEN / 3];
+            let count = mixer.read(&mut buf).unwrap();
+            mixer.seek_on_layer("test1", SampleDuration::from_samples(samples))
+                .unwrap();
+            let result = rambot_test_util::read_to_end(&mut mixer).unwrap();
 
-        rambot_test_util::assert_approximately_equal(
-            &test_audio_1()[..count], &buf[..count]);
-        rambot_test_util::assert_approximately_equal(
-            &test_audio_1()[((count as i64 + samples) as usize)..], &result)
+            rambot_test_util::assert_approximately_equal(
+                &test_audio_1()[..count], &buf[..count]);
+            rambot_test_util::assert_approximately_equal(
+                &test_audio_1()[((count as i64 + samples) as usize)..], &result)
+        }
     }
 
     #[test]


### PR DESCRIPTION
Extended the `AudioSource` trait by a `seek` method that allows moving the reader through time. Added a `!seek` command to allow users to invoke this new method.

Also, fixed an issue with the audio buffer that seems to only occur when reading into very large buffers.

In addition, test cases were improved and fixed. In particular, this resolves #140.