### PR TITLE
Adapter tests

### DIFF
--- a/plugin-loop/Cargo.toml
+++ b/plugin-loop/Cargo.toml
@@ -10,3 +10,6 @@ crate-type = [ "cdylib" ]
 
 [dependencies]
 rambot-api = { path = "../rambot-api" }
+
+[dev-dependencies]
+rambot-test-util = { path = "../rambot-test-util", features = [ "testing" ] }

--- a/plugin-shuffle/Cargo.toml
+++ b/plugin-shuffle/Cargo.toml
@@ -11,3 +11,6 @@ crate-type = [ "cdylib" ]
 [dependencies]
 rambot-api = { path = "../rambot-api" }
 rand = { version = "0.8", features = [ "small_rng" ] }
+
+[dev-dependencies]
+rambot-test-util = { path = "../rambot-test-util", features = [ "testing" ] }

--- a/rambot-test-util/src/lib.rs
+++ b/rambot-test-util/src/lib.rs
@@ -329,7 +329,7 @@ where
 }
 
 /// Collectes all entries in the given audio source `list` into a vector. Any
-/// errors raised in [AudioSourceList::read] will be forwarded. If the list
+/// errors raised in [AudioSourceList::next] will be forwarded. If the list
 /// contains more than `max_len` entries, only the first `max_len` entries are
 /// queried and collected.
 pub fn collect_list(list: &mut Box<dyn AudioSourceList + Send + Sync>,

--- a/rambot/src/audio.rs
+++ b/rambot/src/audio.rs
@@ -1005,9 +1005,8 @@ mod tests {
         PluginGuildConfig
     };
 
-    use rambot_test_util::MockAudioSource;
+    use rambot_test_util::{MockAudioSource, MockAudioSourceList};
 
-    use std::vec::IntoIter;
     use std::sync::Mutex;
 
     fn pcm_read_to_end<S>(mut buf: &mut [u8], read: &mut PCMRead<S>) -> usize
@@ -1193,16 +1192,6 @@ mod tests {
         }
     }
 
-    struct MockAudioSourceList {
-        entries: IntoIter<String>
-    }
-
-    impl AudioSourceList for MockAudioSourceList {
-        fn next(&mut self) -> Result<Option<String>, io::Error> {
-            Ok(self.entries.next())
-        }
-    }
-
     struct MockAudioSourceListResolver;
 
     impl AudioSourceListResolver for MockAudioSourceListResolver {
@@ -1216,12 +1205,11 @@ mod tests {
 
         fn resolve(&self, descriptor: &str, _: PluginGuildConfig)
                 -> Result<Box<dyn AudioSourceList + Send + Sync>, String> {
-            Ok(Box::new(MockAudioSourceList {
-                entries: descriptor.split(',')
-                    .map(|s| s.to_owned())
-                    .collect::<Vec<_>>()
-                    .into_iter()
-            }))
+            let entries = descriptor.split(',')
+                .map(|s| s.to_owned())
+                .collect::<Vec<_>>();
+
+            Ok(Box::new(MockAudioSourceList::new(entries)))
         }
     }
 


### PR DESCRIPTION
Added new test cases for the standard adapters (loop and shuffle).
Also, re-activated the length check in buffer equality assertions (which was forgotten from a previous debugging session).