### PR TITLE
Sound board toggle buttons

### DIFF
--- a/rambot/src/command/board/mod.rs
+++ b/rambot/src/command/board/mod.rs
@@ -443,11 +443,11 @@ impl EventHandler for BoardButtonEventHandler {
             let message_id = interaction.message.id;
             let button_id: usize = interaction.data.custom_id.parse().unwrap();
             let board_manager =
-                unwrap_or_return!(get_board_manager(&ctx, guild_id).await, ());
+                unwrap_or_return!(get_board_manager(&ctx, guild_id).await, {});
             let button = unwrap_or_return!(
                 board_manager.active_board(message_id, channel_id)
                     .and_then(|b| b.buttons.get(button_id))
-                    .cloned(), ());
+                    .cloned(), {});
 
             drop(board_manager);
 

--- a/rambot/src/command/mod.rs
+++ b/rambot/src/command/mod.rs
@@ -410,7 +410,7 @@ async fn stop_all_do(ctx: &Context, msg: &Message) -> Option<String> {
     let guild_id = msg.guild_id.unwrap();
     let guild_state = unwrap_or_return!(
         get_guild_state(ctx, guild_id).await,
-        Some(format!("No audio to stop.")));
+        Some("No audio to stop.".to_owned()));
 
     if guild_state.mixer_mut().stop_all() {
         None


### PR DESCRIPTION
Added the option to specify a deactivate command for sound board buttons, transforming them into toggle buttons which execute the deactivate command on every second push. This resolves #136
Also, reworked the factorization of guild state and board manager accesses in the command module to use guards instead of closures (due to issues with async usage).